### PR TITLE
docs: susie inf method reloacated with the rest of the methods

### DIFF
--- a/docs/python_api/methods/susie_inf.md
+++ b/docs/python_api/methods/susie_inf.md
@@ -1,6 +1,8 @@
 ---
-title: SuSiE-inf - Fine-mapping with infinitesimal effects v1.1
+title: SuSiE-inf
 ---
+
+# SuSiE-inf - Fine-mapping with infinitesimal effects v1.1
 
 This is an implementation of the SuSiE-inf method found here:
 https://github.com/FinucaneLab/fine-mapping-inf


### PR DESCRIPTION
In `https://opentargets.github.io/gentropy/python_api/method/susie_inf/`

![Screenshot 2024-02-08 at 13 36 17](https://github.com/opentargets/gentropy/assets/5097586/a4dfd991-461a-4da4-856d-5552bdc4a993)

with these changes doing `poetry run mkdocs serve`

![Screenshot 2024-02-08 at 13 42 42](https://github.com/opentargets/gentropy/assets/5097586/4a4c6060-7dba-47ea-b64b-632794f1117d)
