### PR TITLE
fix: cohort extraction on latest GWAS Catalog release files

### DIFF
--- a/src/gentropy/datasource/gwas_catalog/study_index.py
+++ b/src/gentropy/datasource/gwas_catalog/study_index.py
@@ -330,7 +330,7 @@ class StudyIndexGWASCatalogParser:
         # Read GWAS Catalogue raw data
         return (
             cls._parse_study_table(catalog_studies)
-            .annotate_ancestries(ancestry_file)
+            .annotate_ancestries(ancestry_file, catalog_studies)
             .annotate_sumstats_info(sumstats_lut)
             .annotate_discovery_sample_sizes()
         )
@@ -520,7 +520,7 @@ class StudyIndexGWASCatalog(StudyIndex):
         )
 
     def annotate_ancestries(
-        self: StudyIndexGWASCatalog, ancestry_lut: DataFrame
+        self: StudyIndexGWASCatalog, ancestry_lut: DataFrame, catalog_studies: DataFrame
     ) -> StudyIndexGWASCatalog:
         """Extracting sample sizes and ancestry information.
 
@@ -529,6 +529,7 @@ class StudyIndexGWASCatalog(StudyIndex):
 
         Args:
             ancestry_lut (DataFrame): Ancestry table as downloaded from the GWAS Catalog
+            catalog_studies (DataFrame): GWAS Catalog study table
 
         Returns:
             StudyIndexGWASCatalog: Slimmed and cleaned version of the ancestry annotation.


### PR DESCRIPTION
## ✨ Context

I tried to run `gwas_catalog_ingestion` from the gentropy package. It seems that this step does not work with the current GWAS Catalog files. (I downloaded the `catalog_study_files`, `catalog_ancestry_files` and `catalog_associations_file` from here: https://ftp.ebi.ac.uk/pub/databases/gwas/releases/2024/03/04/)

To be more specific, the `COHORT(S)` header was removed from the `catalog_ancestry_files`. However, it was placed back in the `catalog_study_files` as `COHORT`. See documentation from GWAS Catalog: https://www.ebi.ac.uk/gwas/docs/fileheaders#_file_headers_for_unpublished_ancestries

I believe @DSuveges has found this as well. See his 3rd task in this PR: https://github.com/opentargets/gentropy/pull/507 

## 🛠 What does this PR implement

This PR makes sure the COHORT(S) are extracted from the `catalog_study_files`.
Sample files and pytests have been updated.
Note that I had to update pre-commit-config.yaml as well. (It updated while running `make setup-dev`. Not including the files made pre-commit run into errors)

## 🙈 Missing

I am not yet aware of the full gentropy package. Could there be any other steps that use the `COHORT(S)` header from the `catalog_ancestry_files`?

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
