### PR TITLE
chore: update ruff pre-commit and rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autofix_commit_msg: "chore: pre-commit auto fixes [...]"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.3.0
     hooks:
       - id: ruff
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,13 +158,14 @@ module = [
 ignore_missing_imports = true
 
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
   "B002",    # Python does not support the unary prefix increment
   "B007",    # Loop control variable {name} not used within loop body
   "B014",    # Exception handler with duplicate exception
   "B023",    # Function definition does not bind loop variable {name}
   "B026",    # Star-arg unpacking after a keyword argument is strongly discouraged
+  "B904",    # Checks for raise statements in exception handlers that lack a from clause
   "C",       # complexity
   "COM818",  # Trailing comma on bare tuple prohibited
   "D",       # docstrings
@@ -179,7 +180,6 @@ select = [
   "N804",    # First argument of a class method should be named cls
   "N805",    # First argument of a method should be named self
   "N815",    # Variable {name} in class scope should not be mixedCase
-  "PGH001",  # No builtin eval() allowed
   "PGH004",  # Use specific rule codes when using noqa
   "PLC0414", # Useless import alias. Import alias does not rename original package.
   "PLC",     # pylint
@@ -218,7 +218,6 @@ select = [
   "T20",     # flake8-print
   "TID251",  # Banned imports
   "TRY004",  # Prefer TypeError exception for invalid type
-  "TRY200",  # Use raise from to specify exception cause
   "TRY302",  # Remove exception handler; error is immediately re-raised
   "UP",      # pyupgrade
   "W",       # pycodestyle

--- a/tests/airflow/test_dag.py
+++ b/tests/airflow/test_dag.py
@@ -1,4 +1,5 @@
 """Check for airflow import errors. Inspiration from https://garystafford.medium.com/devops-for-dataops-building-a-ci-cd-pipeline-for-apache-airflow-dags-975e4a622f83."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/gentropy/common/test_session.py
+++ b/tests/gentropy/common/test_session.py
@@ -1,4 +1,5 @@
 """Tests GWAS Catalog study splitter."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/gentropy/conftest.py
+++ b/tests/gentropy/conftest.py
@@ -1,4 +1,5 @@
 """Unit test configuration."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/gentropy/dataset/test_colocalisation.py
+++ b/tests/gentropy/dataset/test_colocalisation.py
@@ -1,4 +1,5 @@
 """Test colocalisation dataset."""
+
 from __future__ import annotations
 
 from gentropy.dataset.colocalisation import Colocalisation

--- a/tests/gentropy/dataset/test_dataset.py
+++ b/tests/gentropy/dataset/test_dataset.py
@@ -1,4 +1,5 @@
 """Test Dataset class."""
+
 from __future__ import annotations
 
 import pyspark.sql.functions as f

--- a/tests/gentropy/dataset/test_gene_index.py
+++ b/tests/gentropy/dataset/test_gene_index.py
@@ -1,4 +1,5 @@
 """Tests on LD index."""
+
 from __future__ import annotations
 
 from gentropy.dataset.gene_index import GeneIndex

--- a/tests/gentropy/dataset/test_intervals.py
+++ b/tests/gentropy/dataset/test_intervals.py
@@ -1,4 +1,5 @@
 """Tests on LD index."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/gentropy/dataset/test_l2g.py
+++ b/tests/gentropy/dataset/test_l2g.py
@@ -1,4 +1,5 @@
 """Tests on L2G datasets."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -168,7 +169,7 @@ def test_calculate_feature_missingness_rate(spark: SparkSession) -> None:
     observed_missingness = fm.calculate_feature_missingness_rate()
     assert isinstance(observed_missingness, dict)
     assert len(observed_missingness) == len(
-        fm.features_list  # type: ignore
+        fm.features_list
     ), "Missing features in the missingness rate dictionary."
     assert (
         observed_missingness == expected_missingness

--- a/tests/gentropy/dataset/test_l2g.py
+++ b/tests/gentropy/dataset/test_l2g.py
@@ -168,7 +168,7 @@ def test_calculate_feature_missingness_rate(spark: SparkSession) -> None:
     expected_missingness = {"distanceTssMean": 0.0, "distanceTssMinimum": 1.0}
     observed_missingness = fm.calculate_feature_missingness_rate()
     assert isinstance(observed_missingness, dict)
-    assert len(observed_missingness) == len(
+    assert fm.features_list is not None and len(observed_missingness) == len(
         fm.features_list
     ), "Missing features in the missingness rate dictionary."
     assert (

--- a/tests/gentropy/dataset/test_ld_index.py
+++ b/tests/gentropy/dataset/test_ld_index.py
@@ -1,4 +1,5 @@
 """Tests on LD index."""
+
 from __future__ import annotations
 
 from gentropy.dataset.ld_index import LDIndex

--- a/tests/gentropy/dataset/test_study_index.py
+++ b/tests/gentropy/dataset/test_study_index.py
@@ -1,4 +1,5 @@
 """Test study index dataset."""
+
 from __future__ import annotations
 
 from gentropy.dataset.study_index import StudyIndex

--- a/tests/gentropy/dataset/test_study_locus.py
+++ b/tests/gentropy/dataset/test_study_locus.py
@@ -1,4 +1,5 @@
 """Test study locus dataset."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/tests/gentropy/dataset/test_study_locus_overlap.py
+++ b/tests/gentropy/dataset/test_study_locus_overlap.py
@@ -1,4 +1,5 @@
 """Test study locus overlap dataset."""
+
 from __future__ import annotations
 
 from gentropy.dataset.study_locus_overlap import StudyLocusOverlap

--- a/tests/gentropy/dataset/test_study_locus_overlaps.py
+++ b/tests/gentropy/dataset/test_study_locus_overlaps.py
@@ -1,4 +1,5 @@
 """Test colocalisation dataset."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/tests/gentropy/dataset/test_summary_statistics.py
+++ b/tests/gentropy/dataset/test_summary_statistics.py
@@ -1,4 +1,5 @@
 """Test study index dataset."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/gentropy/dataset/test_v2g.py
+++ b/tests/gentropy/dataset/test_v2g.py
@@ -1,4 +1,5 @@
 """Tests V2G dataset."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/gentropy/dataset/test_variant_annotation.py
+++ b/tests/gentropy/dataset/test_variant_annotation.py
@@ -1,4 +1,5 @@
 """Tests variant annotation dataset."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/gentropy/dataset/test_variant_index.py
+++ b/tests/gentropy/dataset/test_variant_index.py
@@ -1,4 +1,5 @@
 """Tests on variant index generation."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/gentropy/datasource/gwas_catalog/test_gwas_catalog_study_splitter.py
+++ b/tests/gentropy/datasource/gwas_catalog/test_gwas_catalog_study_splitter.py
@@ -1,4 +1,5 @@
 """Tests GWAS Catalog study splitter."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/tests/gentropy/datasource/intervals/test_andersson.py
+++ b/tests/gentropy/datasource/intervals/test_andersson.py
@@ -1,4 +1,5 @@
 """Test Andersson Intervals."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/gentropy/datasource/intervals/test_javierre.py
+++ b/tests/gentropy/datasource/intervals/test_javierre.py
@@ -1,4 +1,5 @@
 """Test JavierreIntervals."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/gentropy/datasource/intervals/test_jung.py
+++ b/tests/gentropy/datasource/intervals/test_jung.py
@@ -1,4 +1,5 @@
 """Test Jung Intervals."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/gentropy/datasource/intervals/test_thurman.py
+++ b/tests/gentropy/datasource/intervals/test_thurman.py
@@ -1,4 +1,5 @@
 """Test Thurman."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/gentropy/datasource/open_targets/test_l2g_gold_standard.py
+++ b/tests/gentropy/datasource/open_targets/test_l2g_gold_standard.py
@@ -1,4 +1,5 @@
 """Test Open Targets L2G gold standards data source."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/gentropy/datasource/open_targets/test_target.py
+++ b/tests/gentropy/datasource/open_targets/test_target.py
@@ -1,4 +1,5 @@
 """Test Open Targets target data source."""
+
 from __future__ import annotations
 
 from gentropy.dataset.gene_index import GeneIndex

--- a/tests/gentropy/docs/test_applying_methods.py
+++ b/tests/gentropy/docs/test_applying_methods.py
@@ -1,4 +1,5 @@
 """Testing applying methods docs."""
+
 from typing import Any
 
 import pytest

--- a/tests/gentropy/docs/test_create_dataset.py
+++ b/tests/gentropy/docs/test_create_dataset.py
@@ -1,4 +1,5 @@
 """Testing creating dataset docs."""
+
 from typing import Any
 
 import pytest

--- a/tests/gentropy/docs/test_creating_spark_session.py
+++ b/tests/gentropy/docs/test_creating_spark_session.py
@@ -1,4 +1,5 @@
 """Testing creating spark session docs."""
+
 from gentropy.common.session import Session
 
 from docs.src_snippets.howto.python_api.a_creating_spark_session import (

--- a/tests/gentropy/docs/test_inspect_dataset.py
+++ b/tests/gentropy/docs/test_inspect_dataset.py
@@ -1,4 +1,5 @@
 """Testing inspecting dataset docs."""
+
 from gentropy.dataset.summary_statistics import SummaryStatistics
 from pyspark.sql.types import StructType
 

--- a/tests/gentropy/method/test_window_based_clumping.py
+++ b/tests/gentropy/method/test_window_based_clumping.py
@@ -1,4 +1,5 @@
 """Test window-based clumping."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/gentropy/step/test_clump_step.py
+++ b/tests/gentropy/step/test_clump_step.py
@@ -1,4 +1,5 @@
 """Test clump step."""
+
 from __future__ import annotations
 
 import tempfile

--- a/tests/gentropy/test_cli.py
+++ b/tests/gentropy/test_cli.py
@@ -1,4 +1,5 @@
 """Test the command-line interface (CLI)."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/gentropy/test_schemas.py
+++ b/tests/gentropy/test_schemas.py
@@ -1,4 +1,5 @@
 """Tests on spark schemas."""
+
 from __future__ import annotations
 
 import json

--- a/tests/gentropy/test_spark_helpers.py
+++ b/tests/gentropy/test_spark_helpers.py
@@ -1,4 +1,5 @@
 """Tests on helper spark functions."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any


### PR DESCRIPTION
## ✨ Context

Updates ruff pre-commit from 0.2.2 to 0.3.0.

After update, the next warnings and file changes were triggered

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'flake8-quotes' -> 'lint.flake8-quotes'
  - 'pydocstyle' -> 'lint.pydocstyle'
  - 'per-file-ignores' -> 'lint.per-file-ignores'
warning: `PGH001` has been remapped to `S307`.
warning: `TRY200` has been remapped to `B904`.
warning: The following rules may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
33 files reformatted, 20 files left unchanged
```

## 🛠 What does this PR implement

pre-commit.yaml update and the necessary changes in the codebase associated with the new formatting and rule changes. 

This PR addresses the above comments.

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
