### PR TITLE
fix: make setup dev not to update pre-commits

### DIFF
--- a/utils/install_dependencies.sh
+++ b/utils/install_dependencies.sh
@@ -30,7 +30,6 @@ poetry install --sync
 
 echo "Setting up pre-commit..."
 poetry run pre-commit install
-poetry run pre-commit autoupdate
 poetry run pre-commit install --hook-type commit-msg
 
 echo "Activating the Poetry environment..."


### PR DESCRIPTION
## ✨ Context

When running `make setup-dev` the pre-commits are updated using the auto-update functionality. This is not a good idea as any time someone installs a local environment it pollutes that branch with updates in the pre-commit hooks and breaks the 1 branch -> 1 feature rule.

This was observed in #515 

## 🛠 What does this PR implement

Remove pre-commit autoupdate from make setup-dev  

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
