### PR TITLE
chore(l2g): update inclusion features list with newer QTLs

### DIFF
--- a/src/gentropy/assets/schemas/l2g_feature_matrix.json
+++ b/src/gentropy/assets/schemas/l2g_feature_matrix.json
@@ -125,6 +125,30 @@
       "name": "sqtlColocLlrMaximumNeighborhood",
       "nullable": true,
       "type": "float"
+    },
+    {
+      "metadata": {},
+      "name": "tuqtlColocClppMaximum",
+      "nullable": true,
+      "type": "float"
+    },
+    {
+      "metadata": {},
+      "name": "tuqtlColocClppMaximumNeighborhood",
+      "nullable": true,
+      "type": "float"
+    },
+    {
+      "metadata": {},
+      "name": "tuqtlColocLlrMaximum",
+      "nullable": true,
+      "type": "float"
+    },
+    {
+      "metadata": {},
+      "name": "tuqtlColocLlrMaximumNeighborhood",
+      "nullable": true,
+      "type": "float"
     }
   ],
   "type": "struct"

--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -213,13 +213,17 @@ class LocusToGeneConfig(StepConfig):
             # max clpp for each (study, locus) aggregating over all eQTLs
             "eqtlColocClppMaximumNeighborhood",
             # max clpp for each (study, locus, gene) aggregating over all pQTLs
-            # "pqtlColocClppMaximum",
+            "pqtlColocClppMaximum",
             # max clpp for each (study, locus) aggregating over all pQTLs
-            # "pqtlColocClppMaximumNeighborhood",
+            "pqtlColocClppMaximumNeighborhood",
             # max clpp for each (study, locus, gene) aggregating over all sQTLs
-            # "sqtlColocClppMaximum",
+            "sqtlColocClppMaximum",
             # max clpp for each (study, locus) aggregating over all sQTLs
-            # "sqtlColocClppMaximumNeighborhood",
+            "sqtlColocClppMaximumNeighborhood",
+            # max clpp for each (study, locus) aggregating over all tuQTLs
+            "tuqtlColocClppMaximum",
+            # max clpp for each (study, locus, gene) aggregating over all tuQTLs
+            "tuqtlColocClppMaximumNeighborhood",
             # # max log-likelihood ratio value for each (study, locus, gene) aggregating over all eQTLs
             # "eqtlColocLlrLocalMaximum",
             # # max log-likelihood ratio value for each (study, locus) aggregating over all eQTLs


### PR DESCRIPTION
## ✨ Context

After the work in https://github.com/opentargets/issues/issues/3235, we have colocalisation results between gwas and pQTLs, sQTLs and tuQTLs that can be used in L2G.

## 🛠 What does this PR implement

This PR adapts the configuration to include the new analyses. Mainly:
- Update L2GFeatureMatrix schema
- Update L2G features list inclusion list so that the model is trained using the full set of features

## 🙈 Missing

A nicer implementation of this where the FM schema doesn't need to be adjusted (https://github.com/opentargets/issues/issues/3146)

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
