### PR TITLE
chore(airflow): remove hardcoded value for gentropy version

### DIFF
--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib.metadata import version as importlib_version
 from typing import TYPE_CHECKING, Any, Optional
 
 import pendulum
@@ -18,8 +19,7 @@ from google.cloud import dataproc_v1, storage
 if TYPE_CHECKING:
     from pathlib import Path
 
-# Code version. It has to be repeated here as well as in `pyproject.toml`, because Airflow isn't able to look at files outside of its `dags/` directory.
-GENTROPY_VERSION = "0.0.0"
+GENTROPY_VERSION = importlib_version("gentropy")
 
 # Cloud configuration.
 GCP_PROJECT = "open-targets-genetics-dev"


### PR DESCRIPTION
## ✨ Context

We had to keep the GENTROPY_VERSION value in sync with the code version to run DAGs.

Apparently setting a specific variable in the package to specify the version is controversial because, although it might be handy like for this case, you have to maintain it and people complain that it lacks standardisation (`__version__` vs `VERSION` vs `package.get_version()`). There are some guides [now](https://packaging.python.org/en/latest/guides/single-sourcing-package-version/), but given the small use case I think this is the least compromised solution.

## 🛠 What does this PR implement

This is based on this SO [thread](https://stackoverflow.com/questions/72167802/adding-version-attribute-to-python-module/72168209#72168209). `importlib` doesn't access the info in the TOML, it just reads the version variable stored in a the package metadata.


## 🙈 Missing


## 🚦 Before submitting

- [X] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
