### PR TITLE
fix(coloc): handle cases when the bayes factors are null

### DIFF
--- a/src/gentropy/method/colocalisation.py
+++ b/src/gentropy/method/colocalisation.py
@@ -72,8 +72,8 @@ class ECaviar:
                 overlapping_signals.df.withColumn(
                     "clpp",
                     ECaviar._get_clpp(
-                        f.col("left_posteriorProbability"),
-                        f.col("right_posteriorProbability"),
+                        f.col("statistics.left_posteriorProbability"),
+                        f.col("statistics.right_posteriorProbability"),
                     ),
                 )
                 .groupBy("leftStudyLocusId", "rightStudyLocusId", "chromosome")


### PR DESCRIPTION
## ✨ Context
Testing COLOC's behaviour when Bayes Factors aren't present I observed that null values of logBF weren't filled with 0:
```
+----------------+-----------------+----------+------------+------------+
|leftStudyLocusId|rightStudyLocusId|chromosome|tagVariantId|  statistics|
+----------------+-----------------+----------+------------+------------+
|               1|                2|         1|         snp|{null, null}|
+----------------+-----------------+----------+------------+------------+

df.fillna(0, subset=["statistics.left_logBF", "statistics.right_logBF"]).withColumn(
    "sum_log_bf",
    f.col("statistics.left_logBF") + f.col("statistics.right_logBF"),
).show()
+----------------+-----------------+----------+------------+------------+----------+
|leftStudyLocusId|rightStudyLocusId|chromosome|tagVariantId|  statistics|sum_log_bf|
+----------------+-----------------+----------+------------+------------+----------+
|               1|                2|         1|         snp|{null, null}|      null|
+----------------+-----------------+----------+------------+------------+----------+
```

The outcome of this is that `Coloc.colocalise` crashes because `get_logsum` can't handle nulls.

I don't think this had implications in the outputs of https://github.com/opentargets/gentropy/pull/530, because all data had Bayes Factors.

## 🛠 What does this PR implement

- The fix is simple. `fillna` is a function that operates in columns that are not nested. Unnesting the BFs fields fixes the problem.
- I've added a semantic test that makes sure that if no credible sets have a BF, `Coloc.colocalise` won't crash and the results will basically show no signs of colocalisation.

## 🙈 Missing


## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
