### PR TITLE
fix: removing all duplicated variants in sumstats for finemapping functions

### DIFF
--- a/src/gentropy/susie_finemapper.py
+++ b/src/gentropy/susie_finemapper.py
@@ -81,6 +81,10 @@ class SusieFineMapperStep:
             .filter(f.col("studyId") == studyId)
             .filter(f.col("z").isNotNull())
         )
+        # Remove ALL duplicated variants from GWAS DataFrame - we don't know which is correct
+        variant_counts = gwas_df.groupBy("variantId").count()
+        unique_variants = variant_counts.filter(f.col("count") == 1)
+        gwas_df = gwas_df.join(unique_variants, on="variantId", how="left_semi")
 
         ld_index = (
             GnomADLDMatrix()
@@ -320,6 +324,10 @@ class SusieFineMapperStep:
             .withColumn("position", f.split(f.col("variantId"), "_")[1])
             .filter(f.col("z").isNotNull())
         )
+        # Remove ALL duplicated variants from GWAS DataFrame - we don't know which is correct
+        variant_counts = gwas_df.groupBy("variantId").count()
+        unique_variants = variant_counts.filter(f.col("count") == 1)
+        gwas_df = gwas_df.join(unique_variants, on="variantId", how="left_semi")
 
         ld_index = (
             GnomADLDMatrix()


### PR DESCRIPTION
## ✨ Context

Some sumstats files have duplicated variant rows, where it isn't clear which is the correct entry. This causes errors in the finemapping pipelines, specifically when extracting the gnomad blockmatrix. 

## 🛠 What does this PR implement

adds a few lines to remove ALL variants that appear more than once in the sumstats prior to finemapping. 

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [ ] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ ] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
