### PR TITLE
feat(airflow): prototype finemapping batch job

### DIFF
--- a/src/airflow/dags/susie_finemapping.py
+++ b/src/airflow/dags/susie_finemapping.py
@@ -1,0 +1,89 @@
+"""Example Airflow DAG that uses Google Cloud Batch Operators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import common_airflow as common
+from airflow.models.dag import DAG
+from airflow.providers.google.cloud.operators.cloud_batch import (
+    CloudBatchSubmitJobOperator,
+)
+from google.cloud import batch_v1
+
+PROJECT_ID = "open-targets-genetics-dev"
+REGION = "europe-west1"
+
+
+def _finemapping_batch_job(studyloci_ids: list[str]) -> batch_v1.Job:
+    """Create a Batch job to run fine-mapping on a list of study loci.
+
+    Args:
+        studyloci_ids (list[str]): A list of study loci IDs to run fine-mapping on.
+
+    Returns:
+        batch_v1.Job: A Batch job to run fine-mapping on the given study loci.
+    """
+    runnable = batch_v1.Runnable()
+    runnable.container = batch_v1.Runnable.Container()
+    runnable.container.image_uri = "europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app-dev/gentropy_test:0.1"
+    runnable.container.entrypoint = "/bin/sh"
+    runnable.container.commands = [
+        "-c",
+        "echo We are going to finemap this studyLocusId $STUDYLOCUSID",
+    ]
+
+    task = batch_v1.TaskSpec()
+    task.runnables = [runnable]
+
+    resources = batch_v1.ComputeResource()
+    resources.cpu_milli = 2000
+    resources.memory_mib = 16
+    task.compute_resource = resources
+    task.max_retry_count = 0
+
+    group = batch_v1.TaskGroup()
+
+    task_env = [
+        batch_v1.Environment(variables={"STUDYLOCUSID": study_locus_id})
+        for study_locus_id in studyloci_ids
+    ]
+    group.task_environments = task_env
+    group.task_spec = task
+    policy = batch_v1.AllocationPolicy.InstancePolicy()
+    policy.machine_type = "e2-standard-4"
+    instances = batch_v1.AllocationPolicy.InstancePolicyOrTemplate()
+    instances.policy = policy
+    allocation_policy = batch_v1.AllocationPolicy()
+    allocation_policy.instances = [instances]
+
+    job = batch_v1.Job()
+    job.task_groups = [group]
+    job.allocation_policy = allocation_policy
+    job.labels = {"env": "testing", "type": "container"}
+
+    job.logs_policy = batch_v1.LogsPolicy()
+    job.logs_policy.destination = batch_v1.LogsPolicy.Destination.CLOUD_LOGGING
+
+    return job
+
+
+with DAG(
+    dag_id=Path(__file__).stem,
+    description="Open Targets Genetics — eQTL preprocess",
+    default_args=common.shared_dag_args,
+    **common.shared_dag_kwargs,
+) as dag:
+    study_loci_ids = ["1"]
+
+    finemapping_job = CloudBatchSubmitJobOperator(
+        task_id="finemapping_batch_job",
+        project_id=PROJECT_ID,
+        region=REGION,
+        job_name="finemapping-job",
+        job=_finemapping_batch_job(study_loci_ids),
+        dag=dag,
+        deferrable=False,
+    )
+
+    (finemapping_job)

--- a/src/airflow/dags/susie_finemapping.py
+++ b/src/airflow/dags/susie_finemapping.py
@@ -1,7 +1,8 @@
-"""Example Airflow DAG that uses Google Cloud Batch Operators."""
+"""Airflow DAG that uses Google Cloud Batch to run the SuSie Finemapper step."""
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import common_airflow as common
@@ -13,25 +14,47 @@ from google.cloud import batch_v1
 
 PROJECT_ID = "open-targets-genetics-dev"
 REGION = "europe-west1"
+GENTROPY_DOCKER_IMAGE = "europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app-dev/gentropy_test:latest"
+STUDY_LOCUS_PATH = "gs://genetics-portal-dev-analysis/yt4/toy_studdy_locus_alzheimer"
+STUDY_INDEX_PATH = "gs://gwas_catalog_data/study_index"
+OUTPUT_PATH = "gs://genetics-portal-dev-analysis/irene/tmp_to_delete"
+CREDENTIALS_REMOTE_LOCATION = (
+    "gs://genetics-portal-dev-analysis/irene/service_account_credentials.json"
+)
 
 
-def _finemapping_batch_job(studyloci_ids: list[str]) -> batch_v1.Job:
+def _finemapping_batch_job(
+    studyloci_ids: list[str],
+    docker_image_url: str,
+    study_locus_collected_path: str,
+    study_index_path: str,
+    output_path: str,
+    locus_radius: int,
+    max_causal_snps: int,
+) -> batch_v1.Job:
     """Create a Batch job to run fine-mapping on a list of study loci.
 
     Args:
         studyloci_ids (list[str]): A list of study loci IDs to run fine-mapping on.
+        docker_image_url (str): The URL of the Docker image to use for the job.
+        study_locus_collected_path (str): The path to the study locus to fine-map.
+        study_index_path (str): The path to the study index.
+        output_path (str): The path to store the output.
+        locus_radius (int): The radius around the study locus to consider for fine-mapping.
+        max_causal_snps (int): The maximum number of causal SNPs to consider.
 
     Returns:
         batch_v1.Job: A Batch job to run fine-mapping on the given study loci.
     """
     runnable = batch_v1.Runnable()
     runnable.container = batch_v1.Runnable.Container()
-    runnable.container.image_uri = "europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app-dev/gentropy_test:0.1"
+    runnable.container.image_uri = docker_image_url
     runnable.container.entrypoint = "/bin/sh"
     runnable.container.commands = [
         "-c",
-        "echo We are going to finemap this studyLocusId $STUDYLOCUSID",
+        rf"poetry run gentropy step=susie_finemapping step.study_locus_to_finemap=$STUDYLOCUSID step.study_locus_collected_path={study_locus_collected_path} step.study_index_path={study_index_path} step.output_path={output_path} step.locus_radius={locus_radius} step.max_causal_snps={max_causal_snps} step.session.extended_spark_conf={{spark.jars:https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar\}}",
     ]
+    runnable.container.options = "-e HYDRA_FULL_ERROR=1"
 
     task = batch_v1.TaskSpec()
     task.runnables = [runnable]
@@ -74,14 +97,20 @@ with DAG(
     default_args=common.shared_dag_args,
     **common.shared_dag_kwargs,
 ) as dag:
-    study_loci_ids = ["1"]
-
     finemapping_job = CloudBatchSubmitJobOperator(
         task_id="finemapping_batch_job",
         project_id=PROJECT_ID,
         region=REGION,
-        job_name="finemapping-job",
-        job=_finemapping_batch_job(study_loci_ids),
+        job_name=f"finemapping-job-{time.strftime('%Y%m%d-%H%M%S')}",
+        job=_finemapping_batch_job(
+            ["6109438569946056978", "6388992474978589194"],
+            GENTROPY_DOCKER_IMAGE,
+            STUDY_LOCUS_PATH,
+            STUDY_INDEX_PATH,
+            OUTPUT_PATH,
+            1000000,
+            10,
+        ),
         dag=dag,
         deferrable=False,
     )

--- a/src/airflow/requirements.txt
+++ b/src/airflow/requirements.txt
@@ -1,3 +1,4 @@
 apache-airflow-providers-google==10.10.1
 apache-airflow-providers-apache-beam==5.6.1
 psycopg2-binary==2.9.9
+cloudpathlib==0.18.1


### PR DESCRIPTION
New Airflow DAG that calls the susie finemapper step on a list of studyLocus IDs to generate credible sets.

## ✨ Context
This is an incremental pipeline, so the first 3 tasks involve the operation of generating a list of studyLocus to finemap. Once the difference is computed, we finemap those IDs as a job to Google Batch.

![image](https://github.com/opentargets/gentropy/assets/45119610/dbd95ee2-4d09-4504-9824-81b0c2fa7409)

Graph nodes:
- `get_all_study_locus_ids`. Lists the bucket with the clumped study locus IDs and extracts all IDs that we could theoretically finemap based on the filename. **A requirement for this step is that clumped study loci are written partitioned by their ID - which is currently not implemented** (e.g. `gs://genetics-portal-dev-analysis/irene/toy_studdy_locus_alzheimer_partitioned`)
- `get_finemapped_paths`. Lists the bucket that contains all credible sets as a result of fine-mapping and extracts the IDs from the filename. **Similarly, it is also required that the SLID is part of the filename.** This is partially implemented, already. The data is not partitioned, but [the ID is used to build the output path](https://github.com/opentargets/gentropy/blob/70e5e2615700518324d414d11165efe025798284/src/gentropy/susie_finemapper.py#L72).
- `get_study_loci_to_finemap`. Creates a list of IDs based on the difference between get_all_study_locus_ids and get_finemapped_paths.
- `finemapping_task`. The one that interfaces with the Google Batch operator to create **one Batch job that runs the Docker container with as many tasks in parallel as studyLoci IDs we have extracted** in get_study_loci_to_finemap. The  command run in the container image calls the fine mapping step with the appropriate parameters.


## 🛠 What does this PR implement

- The DAG explained above.
- A small change in the logic of `SusieFineMapperStep` that instead of passing the row of the studyLocus to finemap, it passes the dataframe (containing that one row). This is to prevent incompatibilities between the input data, and the schema (I had the problem that after partitioning the data by SLID and then reading the data, this column was appended at the end)

## 🙈 Missing

- Testing that the logic works after fixing the schema issues. This requires creating a new image.
- Fine tuning the resources allocated in the Batch job. This crosses over with the work done by @tskir 
- Sorting out the input data for this DAG:
    - First, we need to partitioning the data prior to the finemapping step as required by the `get_all_study_locus_ids` node. This involves changing `ld_based_clumping.py`
    - Then, we have to be mindful that we want to fine map studyLoci from 2 sources: UKBB PPP and GWAS Catalog. So either we run the DAG twice or we put all clumped study loci under the same location.

## 🚦 Before submitting

- [ ] Do these changes cover one single feature (one change at a time)?
- [X] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [X] Did you make sure there is no commented out code in this PR?
- [X] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [X] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [X] Did you make sure the changes pass local tests (`make test`)?
- [X] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
