### PR TITLE
fix: Java 11 in docker image and lighter image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,33 @@
-FROM python:3.10
+FROM python:3.10-bullseye
+
+
+RUN apt-get update && \
+    apt-get install -y openjdk-11-jdk && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN java -version
+
+# Set environment variables for Java
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+ENV PATH=$PATH:$JAVA_HOME/bin
 
 RUN pip install poetry==1.7.1
 
-COPY . .
+ENV POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=1 \
+    POETRY_VIRTUALENVS_CREATE=1 \
+    POETRY_CACHE_DIR=/tmp/poetry_cache
+
+WORKDIR /app
+
+COPY pyproject.toml poetry.lock ./
+RUN touch README.md
+
+RUN poetry config installer.max-workers 10
+RUN poetry install --without dev,docs,tests --no-root --no-interaction --no-ansi -vvv && rm -rf $POETRY_CACHE_DIR
+
+COPY src ./src
+
 RUN poetry install --without dev,docs,tests
 
 ENTRYPOINT ["poetry", "run", "gentropy"]


### PR DESCRIPTION
## ✨ Context

The current Docker image is a bit naive and takes a lot more space than needed. Some dependencies like hail-compatible Java are not there. Also, the code and the dependencies are in different layers which results in much faster build times.

## 🛠 What does this PR implement

- A lighter docker image with more defined layers.
- Java 11 is installed for hail compatibility

## 🙈 Missing

- CI/CD image

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
