### PR TITLE
fix: fix python-semantic-release version (again)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Python Semantic Release
         id: semrelease
-        uses: python-semantic-release/python-semantic-release@9.6.0
+        uses: python-semantic-release/python-semantic-release@v9.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Version requires "v" before number