### PR TITLE
fix(spark helpers): sorter function updated to avoid crash

### DIFF
--- a/src/gentropy/common/spark_helpers.py
+++ b/src/gentropy/common/spark_helpers.py
@@ -1,4 +1,5 @@
 """Common utilities in Spark that can be used across the project."""
+
 from __future__ import annotations
 
 import re
@@ -363,6 +364,7 @@ def order_array_of_structs_by_field(column_name: str, field_name: str) -> Column
         array_sort(
         {column_name},
         (left, right) -> case
+                        when left.{field_name} is null and right.{field_name} is null then 0
                         when left.{field_name} is null then 1
                         when right.{field_name} is null then -1
                         when left.{field_name} < right.{field_name} then 1


### PR DESCRIPTION
## ✨ Context

Upon using `gentropy.common.spark_helpers.order_array_of_structs_by_field` I encountered the following exception:

```
24/05/19 23:17:07 ERROR Utils: Aborting task
java.lang.IllegalArgumentException: Comparison method violates its general contract!
```

which  occurs when the comparison function used in sorting is not transitive, i.e., it does not consistently return the correct ordering of elements. Unfortunately I couldn't reproduce an atomic use case to demonstrate the implicated condition. The core logic:

```python
return f.expr(
    f"""
    array_sort(
    {column_name},
    (left, right) -> case
                    when left.{field_name} is null then 1
                    when right.{field_name} is null then -1
                    when left.{field_name} < right.{field_name} then 1
                    when left.{field_name} > right.{field_name} then -1
                    else 0
            end)
    """
)
```

The issue might be related to the handling of null values. In the cited comparison function, if left.field_name is null, it returns 1, and if right.field_name is null, it returns -1. This means that null values are considered greater than non-null values. However, when both left.field_name and right.field_name are null, the function might not explicitly handle this case and falls to the else clause, returning 0. This might cause inconsistencies in the ordering of elements when null values are involved.

## 🛠 What does this PR implement

Updating the the condition with one line:

```python
return f.expr(
    f"""
    array_sort(
    {column_name},
    (left, right) -> case
                    when left.{field_name} is null and right.{field_name} is null then 0
                    when left.{field_name} is null then 1
                    when right.{field_name} is null then -1
                    when left.{field_name} < right.{field_name} then 1
                    when left.{field_name} > right.{field_name} then -1
                    else 0
            end)
    """
)
```

This modification adds a new condition at the beginning of the case expression to return 0 when both left.field_name and right.field_name are null, indicating that their order doesn't matter. This ensure the transitivity of the comparison function and resolve the error.

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
