### PR TITLE
fix(ld): correct syntax for the `get_numpy_matrix` static method

### DIFF
--- a/src/gentropy/datasource/gnomad/ld.py
+++ b/src/gentropy/datasource/gnomad/ld.py
@@ -503,7 +503,7 @@ class GnomADLDMatrix:
 
         half_matrix = (
             BlockMatrix.read(
-                GnomADLDMatrix.ld_matrix_template.format(POP=gnomad_ancestry)
+                GnomADLDMatrix().ld_matrix_template.format(POP=gnomad_ancestry)
             )
             .filter(idx, idx)
             .to_numpy()


### PR DESCRIPTION
## ✨ Context
Finemapping relies on the `ld` module to perform some operations. This module has an error in its static method, `get_numpy_matrix`.

## 🛠 What does this PR implement
This is a simple fix to ensure the static method works. Note that this is not the most elegant possible solution; it is possible that a static method could be replaced with a better approach, but this is outside the scope of this simple fix PR.

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
