### PR TITLE
fix(susie_finemapper): correct syntax for saving the logs df

### DIFF
--- a/src/gentropy/susie_finemapper.py
+++ b/src/gentropy/susie_finemapper.py
@@ -125,8 +125,9 @@ class SusieFineMapperStep:
                 output_path + "/" + study_locus_to_finemap
             )
             # Write log
-            result_logging["log"].df.write.mode(session.write_mode).parquet(
-                output_path_log + "/" + study_locus_to_finemap
+            result_logging["log"].to_csv(
+                output_path_log + "/" + study_locus_to_finemap + ".csv",
+                index=False
             )
         else:
             result = self.susie_finemapper_ss_gathered(

--- a/src/gentropy/susie_finemapper.py
+++ b/src/gentropy/susie_finemapper.py
@@ -125,8 +125,9 @@ class SusieFineMapperStep:
                 output_path + "/" + study_locus_to_finemap
             )
             # Write log
-            result_logging["log"].to_csv(
-                output_path_log + "/" + study_locus_to_finemap + ".csv",
+            result_logging["log"].to_parquet(
+                output_path_log + "/" + study_locus_to_finemap + ".parquet",
+                engine="pyarrow",
                 index=False
             )
         else:


### PR DESCRIPTION
## ✨ Context
The new version of finemapping, when ran with _logging=True,_ outputs some statistics into a dataframe. However, there's a syntax bug preventing the pipeline from completing.

## 🛠 What does this PR implement
This PR fixes the syntax for outputting the logging dataframe.

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?