### PR TITLE
fix(L2GPrediction): schema validation

### DIFF
--- a/src/gentropy/dataset/l2g_feature_matrix.py
+++ b/src/gentropy/dataset/l2g_feature_matrix.py
@@ -1,4 +1,5 @@
 """Feature matrix of study locus pairs annotated with their functional genomics features."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -35,6 +36,7 @@ class L2GFeatureMatrix(Dataset):
         self.features_list = self.features_list or [
             col for col in self._df.columns if col not in fixed_cols
         ]
+        self.validate_schema()
 
     @classmethod
     def generate_features(

--- a/src/gentropy/dataset/l2g_prediction.py
+++ b/src/gentropy/dataset/l2g_prediction.py
@@ -73,11 +73,13 @@ class L2GPrediction(Dataset):
         gwas_fm = L2GFeatureMatrix(
             _df=(
                 fm.df.join(
-                    credible_set.filter_by_study_type("gwas", study_index).df,
+                    credible_set.filter_by_study_type("gwas", study_index).df.select(
+                        "studyLocusId"
+                    ),
                     on="studyLocusId",
                 )
             ),
-            _schema=cls.get_schema(),
+            _schema=L2GFeatureMatrix.get_schema(),
         )
         return (
             L2GPrediction(

--- a/src/gentropy/dataset/pairwise_ld.py
+++ b/src/gentropy/dataset/pairwise_ld.py
@@ -1,4 +1,5 @@
 """Pairwise LD dataset."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -37,6 +38,7 @@ class PairwiseLD(Dataset):
         ), f"The number of rows in a pairwise LD table has to be square. Got: {row_count}"
 
         self.dimension = (int(sqrt(row_count)), int(sqrt(row_count)))
+        self.validate_schema()
 
     @classmethod
     def get_schema(cls: type[PairwiseLD]) -> StructType:

--- a/tests/gentropy/dataset/test_l2g.py
+++ b/tests/gentropy/dataset/test_l2g.py
@@ -156,7 +156,7 @@ def test_remove_false_negatives(spark: SparkSession) -> None:
 def test_l2g_feature_constructor_with_schema_mismatch(spark: SparkSession) -> None:
     """Test if provided shema mismatch results in error in L2GFeatureMatrix constructor.
 
-    distanceTssMean is expected to be DOUBLE by schema in src.gentropy.assets.schemas and is actualy FLOAT.
+    distanceTssMean is expected to be FLOAT by schema in src.gentropy.assets.schemas and is actualy DOUBLE.
     """
     with pytest.raises(ValueError) as e:
         L2GFeatureMatrix(


### PR DESCRIPTION
## ✨ Context


During the 24.06 data release results check team found `feature_matrix` published at 
```
gsutil du -sh gs://genetics_etl_python_playground/releases/24.06/locus_to_gene_feature_matrix
10.16 GiB    gs://genetics_etl_python_playground/releases/24.06/locus_to_gene_feature_matrix
```

The resulting table schema 

```
root
 |-- studyLocusId: long (nullable = true)
 |-- geneId: string (nullable = true)
 |-- distanceTssMean: float (nullable = true)
 |-- distanceTssMinimum: float (nullable = true)
 |-- eqtlColocClppMaximum: float (nullable = true)
 |-- eqtlColocClppMaximumNeighborhood: float (nullable = true)
 |-- eqtlColocLlrMaximum: float (nullable = true)
 |-- eqtlColocLlrMaximumNeighborhood: float (nullable = true)
 |-- pqtlColocClppMaximum: float (nullable = true)
 |-- pqtlColocClppMaximumNeighborhood: float (nullable = true)
 |-- pqtlColocLlrMaximum: float (nullable = true)
 |-- pqtlColocLlrMaximumNeighborhood: float (nullable = true)
 |-- sqtlColocClppMaximum: float (nullable = true)
 |-- sqtlColocClppMaximumNeighborhood: float (nullable = true)
 |-- sqtlColocLlrMaximum: float (nullable = true)
 |-- sqtlColocLlrMaximumNeighborhood: float (nullable = true)
 |-- tuqtlColocClppMaximum: float (nullable = true)
 |-- tuqtlColocClppMaximumNeighborhood: float (nullable = true)
 |-- tuqtlColocLlrMaximum: float (nullable = true)
 |-- tuqtlColocLlrMaximumNeighborhood: float (nullable = true)
 |-- vepMaximum: float (nullable = true)
 |-- vepMaximumNeighborhood: float (nullable = true)
 |-- vepMean: float (nullable = true)
 |-- vepMeanNeighborhood: float (nullable = true)
 |-- studyId: string (nullable = true)
 |-- variantId: string (nullable = true)
 |-- chromosome: string (nullable = true)
 |-- position: integer (nullable = true)
 |-- region: string (nullable = true)
 |-- beta: double (nullable = true)
 |-- zScore: double (nullable = true)
 |-- pValueMantissa: float (nullable = true)
 |-- pValueExponent: integer (nullable = true)
 |-- effectAlleleFrequencyFromSource: float (nullable = true)
 |-- standardError: double (nullable = true)
 |-- subStudyDescription: string (nullable = true)
 |-- qualityControls: array (nullable = true)
 |    |-- element: string (containsNull = true)
 |-- finemappingMethod: string (nullable = true)
 |-- credibleSetIndex: integer (nullable = true)
 |-- credibleSetlog10BF: double (nullable = true)
 |-- purityMeanR2: double (nullable = true)
 |-- purityMinR2: double (nullable = true)
 |-- locusStart: integer (nullable = true)
 |-- locusEnd: integer (nullable = true)
 |-- sampleSize: integer (nullable = true)
 |-- ldSet: array (nullable = true)
 |    |-- element: struct (containsNull = true)
 |    |    |-- tagVariantId: string (nullable = true)
 |    |    |-- r2Overall: double (nullable = true)
 |-- locus: array (nullable = true)
 |    |-- element: struct (containsNull = true)
 |    |    |-- is95CredibleSet: boolean (nullable = true)
 |    |    |-- is99CredibleSet: boolean (nullable = true)
 |    |    |-- logBF: double (nullable = true)
 |    |    |-- posteriorProbability: double (nullable = true)
 |    |    |-- variantId: string (nullable = true)
 |    |    |-- pValueMantissa: float (nullable = true)
 |    |    |-- pValueExponent: integer (nullable = true)
 |    |    |-- beta: double (nullable = true)
 |    |    |-- standardError: double (nullable = true)
 |    |    |-- r2Overall: double (nullable = true)

```

is different then the expected one in the [L2GFeatureMatrix](https://opentargets.github.io/gentropy/python_api/datasets/l2g_feature_matrix/#schema)

[`Dataset` object](https://github.com/opentargets/gentropy/blob/3c8ce581030b42837fec8b7019c88363dfc28e7a/src/gentropy/dataset/dataset.py#L33) introduces the `__post_init__` method which call the schema validation after the construction of the object. In the context of the child class `L2GFeatureMatrix` the `__post_init__` method from it's parent class - `Dataset` was overwritten without call to the `validate_schema` method.

Construction of `L2GFeatureMatrix` did not validate the schema. This issue only persists when feature matrix is construcred by it's default dataclass constructor. it does not exist when trying to read the feature matrix from file with `from_parquet` method. 

Changing this behavior would introduce schema mismatch in the [`L2GPrediction`](https://github.com/opentargets/gentropy/blob/3c8ce581030b42837fec8b7019c88363dfc28e7a/src/gentropy/dataset/l2g_prediction.py#L76) `from_credible_set` method, as the schema of join result from `L2GFeatureMatrix` and credible sets from `StudyLocus` will append new columns to the object. 

To resolve this issues following steps were added as described in next section. 

The results for new feature matrix after rerunning:
```
gsutil du -sh gs://genetics_etl_python_playground/releases/24.06/locus_to_gene_feature_matrix_2 # new
227.07 MiB   gs://genetics_etl_python_playground/releases/24.06/locus_to_gene_feature_matrix_2
gsutil du -sh gs://genetics_etl_python_playground/releases/24.06/locus_to_gene_feature_matrix  # old
10.16 GiB    gs://genetics_etl_python_playground/releases/24.06/locus_to_gene_feature_matrix
```
<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

- [x] Addition of `validate_schema` method call to all classes with `__post_init__` method that inherit from `Dataset` class
- [x] Selecting only `studyLocusId` field from  credible sets when using them as join filtering to unify the columns
- [x] Change to L2GFeatureMatrix schema provided to the constructor from L2GPrediction to L2GFeatureMatrix

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
