### PR TITLE
chore: enable Jupyter Notebook gateway for the Dataproc cluster

### DIFF
--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -112,6 +112,7 @@ def create_cluster(
         num_workers=num_workers,
         image_version=GCP_DATAPROC_IMAGE,
         enable_component_gateway=True,
+        optional_components=["JUPYTER"],
         init_actions_uris=INITIALISATION_EXECUTABLE_FILE,
         metadata={
             "CONFIGTAR": CONFIG_TAG,


### PR DESCRIPTION
## ✨ Context
Sometimes it is very useful to be able to spin up a Jupyter notebook on a Dataproc cluster which has access to Gentropy and all its configured environment. Previously, I already added the “enable_component_gateway” option; however, it doesn't really take any effect unless you also specify the list of components to enable, which is what I'm doing in this PR.

## 🛠 What does this PR implement
Enable Jupyter Notebook component for the cluster.

## 🙈 Missing
N/A.

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?