### PR TITLE
chore(SusieFineMapperStep): remove the locus_radius parameter

### DIFF
--- a/src/gentropy/susie_finemapper.py
+++ b/src/gentropy/susie_finemapper.py
@@ -47,7 +47,6 @@ class SusieFineMapperStep:
         study_locus_collected_path: str,
         study_index_path: str,
         output_path: str,
-        locus_radius: int = 500_000,
         max_causal_snps: int = 10,
         primary_signal_pval_threshold: float = 1,
         secondary_signal_pval_threshold: float = 1,
@@ -71,7 +70,6 @@ class SusieFineMapperStep:
             study_locus_collected_path (str): path to the collected study locus
             study_index_path (str): path to the study index
             output_path (str): path to the output
-            locus_radius (int): Radius of base-pair window around the locus, default is 500_000
             max_causal_snps (int): Maximum number of causal variants in locus, default is 10
             primary_signal_pval_threshold (float): p-value threshold for the lead variant from the primary signal (credibleSetIndex==1), default is 5e-8
             secondary_signal_pval_threshold (float): p-value threshold for the lead variant from the secondary signals, default is 1e-7


### PR DESCRIPTION
Code inspection shows that it is not used anymore.

## ✨ Context
Recent changes in `SusieFineMapperStep` left a parameter `locus_radius` which is not used anymore.

## 🛠 What does this PR implement
Remove the unused parameter locus_radius.

## 🙈 Missing
N/A

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
