### PR TITLE
fix: typo in `cs_lbf_thr` parameter name

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -418,7 +418,6 @@ class FinemapperConfig(StepConfig):
     study_locus_collected_path: str = MISSING
     study_index_path: str = MISSING
     output_path: str = MISSING
-    locus_radius: int = MISSING
     max_causal_snps: int = MISSING
     primary_signal_pval_threshold: float = MISSING
     secondary_signal_pval_threshold: float = MISSING
@@ -426,7 +425,6 @@ class FinemapperConfig(StepConfig):
     purity_min_r2_threshold: float = MISSING
     cs_lbf_thr: float = MISSING
     sum_pips: float = MISSING
-    logging: bool = MISSING
     susie_est_tausq: bool = MISSING
     run_carma: bool = MISSING
     run_sumstat_imputation: bool = MISSING

--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -424,7 +424,7 @@ class FinemapperConfig(StepConfig):
     secondary_signal_pval_threshold: float = MISSING
     purity_mean_r2_threshold: float = MISSING
     purity_min_r2_threshold: float = MISSING
-    cs_lbf_th: float = MISSING
+    cs_lbf_thr: float = MISSING
     sum_pips: float = MISSING
     logging: bool = MISSING
     susie_est_tausq: bool = MISSING


### PR DESCRIPTION
## ✨ Context
There is a typo in the `cs_lbf_thr` parameter name in the `FinemapperConfig` class. This causes problems when trying to define while triggering a Google Batch job.

## 🛠 What does this PR implement
Fix the typo.

## 🙈 Missing
N/A.

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
