### PR TITLE
fix: make extended_spark_conf an empty dict instead of None

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -17,7 +17,7 @@ class SessionConfig:
     write_mode: str = "errorifexists"
     spark_uri: str = "local[*]"
     hail_home: str = os.path.dirname(hail_location)
-    extended_spark_conf: dict[str, str] | None = None
+    extended_spark_conf: dict[str, str] | None = field(default_factory=dict[str, str])
     _target_: str = "gentropy.common.session.Session"
 
 


### PR DESCRIPTION
## ✨ Context
In some cases, we need to override configuration values from the CLI.

`extended_spark_conf` is a `dict[str,str] | None`, but it is None by default. Because of that, when you try to override or add any keys, you get the following exception:
```
AttributeError: 'NoneType' object has no attribute 'get'
    full_key: step.session.extended_spark_conf
    reference_type=Optional[Dict[str, str]]
    object_type=NoneType
```

## 🛠 What does this PR implement
Instead of being `None`, `extended_spark_conf` is now an empty dict. This does not change anything for the existing code and use cases, but allows us to override it from the CLI.

## 🙈 Missing
N/A

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
