### PR TITLE
fix(SusieFineMapperStep): link configuration and step classes

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -432,6 +432,7 @@ class FinemapperConfig(StepConfig):
     imputed_r2_threshold: float = MISSING
     ld_score_threshold: float = MISSING
     output_path_log: str = MISSING
+    _target_: str = "gentropy.susie_finemapper.SusieFineMapperStep"
 
 
 @dataclass


### PR DESCRIPTION
## ✨ Context
As it is, when the susie_finemapper step is triggered, nothing happens because the configuration class is not linked via _target_ to the step class.

## 🛠 What does this PR implement
Address the problem by linking the classes via the _target_ parameter.

## 🙈 Missing
N/A.

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
