### PR TITLE
fix(finemapping): reconcile changes in the finemapping step with config

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -411,7 +411,6 @@ class FinemapperConfig(StepConfig):
         }
     )
     study_locus_to_finemap: str = MISSING
-    study_locus_collected_path: str = MISSING
     study_index_path: str = MISSING
     output_path: str = MISSING
     max_causal_snps: int = MISSING
@@ -427,7 +426,6 @@ class FinemapperConfig(StepConfig):
     carma_time_limit: int = MISSING
     imputed_r2_threshold: float = MISSING
     ld_score_threshold: float = MISSING
-    output_path_log: str = MISSING
     _target_: str = "gentropy.susie_finemapper.SusieFineMapperStep"
 
 


### PR DESCRIPTION
## ✨ Context
Two values were recently removed from the step in https://github.com/opentargets/gentropy/pull/679.

## 🛠 What does this PR implement
This brings config in alignment with these changes.

## 🙈 Missing
N/A

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
