### PR TITLE
ci: prevent user from rebasing in minimal way

### DIFF
--- a/.github/workflows/pr_release_trigger.yaml
+++ b/.github/workflows/pr_release_trigger.yaml
@@ -15,7 +15,7 @@ jobs:
           source_branch: "dev"
           destination_branch: "main"
           pr_title: "chore: trigger release process"
-          pr_body: ":warning: *This PR requires a MERGE or REBASE COMMIT (Don't squash!)*"
+          pr_body: ":warning: *This PR requires a MERGE COMMIT (Don't squash!)*"
           pr_label: "auto-pr"
           pr_draft: false
           pr_allow_empty: true


### PR DESCRIPTION
## ✨ Context
The last release (v1.4) I have rebased the dev -> main branch in PR https://github.com/opentargets/gentropy/pull/619 , which let us to have conflicting branch histories between main and dev. This PR removes the word "REBASE" from the PR label.

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [ ] Do these changes cover one single feature (one change at a time)?
- [ ] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [ ] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ ] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
