### PR TITLE
fix(variants): explode loci to generate list of variants + tests

### DIFF
--- a/tests/gentropy/datasource/open_targets/test_variants.py
+++ b/tests/gentropy/datasource/open_targets/test_variants.py
@@ -1,0 +1,100 @@
+"""Test suite for the variants module of Open Targets."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from gentropy.dataset.study_locus import StudyLocus
+from gentropy.datasource.open_targets.variants import OpenTargetsVariant
+
+if TYPE_CHECKING:
+    from gentropy.common.session import Session
+    from pyspark.sql import SparkSession
+
+
+class TestOpenTargetsVariant:
+    """Test suite for the OpenTargetsVariant class."""
+
+    def test_as_vcf_df_credible_set(
+        self: TestOpenTargetsVariant,
+        spark: SparkSession,
+        session: Session,
+    ) -> None:
+        """Test the as_vcf_df method."""
+        df_credible_set_df = spark.createDataFrame(
+            [
+                {
+                    "studyLocusId": 1,
+                    "variantId": "1_2_C_G",
+                    "studyId": "study1",
+                    "locus": [
+                        {
+                            "variantId": "1_3_A_T",
+                        },
+                    ],
+                },
+            ],
+            StudyLocus.get_schema(),
+        )
+        observed_df = OpenTargetsVariant.as_vcf_df(session, df_credible_set_df).orderBy(
+            *["#CHROM", "POS", "REF", "ALT"]
+        )
+
+        vcf_cols = ["#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO"]
+        df_credible_set_expected_df = spark.createDataFrame(
+            [
+                ("1", 2, ".", "C", "G", ".", ".", "."),
+                ("1", 3, ".", "A", "T", ".", ".", "."),
+            ],
+            vcf_cols,
+        )
+        assert (
+            observed_df.collect() == df_credible_set_expected_df.collect()
+        ), "Unexpected VCF dataframe."
+
+    def test_as_vcf_df_without_variant_id(
+        self: TestOpenTargetsVariant,
+        spark: SparkSession,
+        session: Session,
+    ) -> None:
+        """Test the as_vcf_df method."""
+        df_without_variant_id_df = spark.createDataFrame(
+            [("rs75493593",)], ["variantRsId"]
+        )
+        observed_df = OpenTargetsVariant.as_vcf_df(
+            session, df_without_variant_id_df
+        ).orderBy(*["#CHROM", "POS", "REF", "ALT"])
+
+        vcf_cols = ["#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO"]
+        df_without_variant_id_expected_df = spark.createDataFrame(
+            [
+                ("17", 7041768, "rs75493593", "G", "C", ".", ".", "."),
+                ("17", 7041768, "rs75493593", "G", "T", ".", ".", "."),
+            ],
+            vcf_cols,
+        )
+
+        assert (
+            observed_df.collect() == df_without_variant_id_expected_df.collect()
+        ), "Unexpected VCF dataframe."
+
+    def test_as_vcf_df_without_rs_id(
+        self: TestOpenTargetsVariant,
+        spark: SparkSession,
+        session: Session,
+    ) -> None:
+        """Test the as_vcf_df method with a dataframe of variants without an annotated variantRsId."""
+        df_without_rs_id_df = spark.createDataFrame([("1_2_x_y",)], ["variantId"])
+        observed_df = OpenTargetsVariant.as_vcf_df(session, df_without_rs_id_df)
+
+        vcf_cols = ["#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO"]
+        df_without_rs_id_expected_df = spark.createDataFrame(
+            [
+                ("1", 2, ".", "x", "y", ".", ".", "."),
+            ],
+            vcf_cols,
+        )
+
+        assert (
+            observed_df.collect() == df_without_rs_id_expected_df.collect()
+        ), "Unexpected VCF dataframe."


### PR DESCRIPTION
## ✨ Context
This PR corresponds to the work of including Platform datasets to enrich the new variant index. It is secondary to #678 
@DSuveges identified during his review that when we processed the Gentropy credible sets, we weren't exploding the variants in the locus.

This PR adds and tests that functionality

## 🛠 What does this PR implement

- Not present columns are handled with a common method so that the same step is applicable to all input dfs
- Addition of `create_empty_column_if_not_exists`
- Unit tests for all scenarios: df with only variant IDs, df with only rsIDs, df with a defined locus

## 🙈 Missing


## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
