### PR TITLE
fix(finemapping): typo in "elapsed_time"

### DIFF
--- a/src/gentropy/susie_finemapper.py
+++ b/src/gentropy/susie_finemapper.py
@@ -823,7 +823,7 @@ class SusieFineMapperStep:
                 "N_outliers": N_outliers,
                 "N_imputed": N_imputed,
                 "N_final_to_fm": len(ld_to_fm),
-                "eleapsed_time": end_time - start_time,
+                "elapsed_time": end_time - start_time,
             },
             index=[0],
         )


### PR DESCRIPTION
## ✨ Context
Finemapping outputs logs as part of its run.

## 🛠 What does this PR implement
Fix the typo in the finemapping logs output: `eleapsed_time` to `elapsed_time`.

## 🙈 Missing
N/A

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
