### PR TITLE
feat: implement reading study locus paths from the manifest

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -427,9 +427,9 @@ class FinemapperConfig(StepConfig):
             "start_hail": True,
         }
     )
-    study_locus_to_finemap: str = MISSING
     study_index_path: str = MISSING
-    output_path: str = MISSING
+    study_locus_manifest_path: str = MISSING
+    study_locus_index: int = MISSING
     max_causal_snps: int = MISSING
     primary_signal_pval_threshold: float = MISSING
     secondary_signal_pval_threshold: float = MISSING


### PR DESCRIPTION
## ✨ Context
Google Batch has issues submitting large payloads. In theory the maximum payload is 10 MB, but in practice environment lists of more than approximately 4,000 tasks per batch job fails.

## 🛠 What does this PR implement
Study locus input and output paths are being read from the CSV manifest, and only the index of a row needs to be specified, which can be done with a predefined `$BATCH_TASK_INDEX` variable.

## 🙈 Missing
N/A.

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
