### PR TITLE
chore(Session): make logs less noisy by not displaying stage progress

### DIFF
--- a/src/gentropy/common/session.py
+++ b/src/gentropy/common/session.py
@@ -69,6 +69,8 @@ class Session:
             .set(
                 "spark.shuffle.service.enabled", "true"
             )  # required for dynamic allocation
+            # Make logs less noisy by not displaying stage progress.
+            .set("spark.ui.showConsoleProgress", "false")
         )
 
     def _hail_config(


### PR DESCRIPTION
## ✨ Context
When examining logs in bulk (such as for a Batch job), a lot of entries look like

```
[Stage 6:>                                                          (0 + 4) / 4][Stage 6:>                                                          (0 + 4) / 4][Stage 6:>                  (0 + 4) / 4][Stage 7:>                  (0 + 0) / 4][Stage 6:>    (0 + 4) / 4][Stage 7:>    (0 + 0) / 4][Stage 8:>    (0 + 0) / 8][Stage 6:>    (0 + 4) / 4][Stage 7:>    (0 + 0) / 4]
```

This is not informative and unnecessarily increases log traffic and decreases their readability.

## 🛠 What does this PR implement
Turns off stage progress logging in console.

## 🙈 Missing
N/A

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
