### PR TITLE
fix: adding carma_tau parameter to susie_finemapper

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -451,6 +451,7 @@ class FinemapperConfig(StepConfig):
     sum_pips: float = MISSING
     susie_est_tausq: bool = MISSING
     run_carma: bool = MISSING
+    carma_tau: float = MISSING
     run_sumstat_imputation: bool = MISSING
     carma_time_limit: int = MISSING
     imputed_r2_threshold: float = MISSING

--- a/src/gentropy/method/carma.py
+++ b/src/gentropy/method/carma.py
@@ -1,4 +1,5 @@
 """CARMA outlier detection method."""
+
 from __future__ import annotations
 
 import concurrent.futures
@@ -18,7 +19,10 @@ class CARMA:
 
     @staticmethod
     def time_limited_CARMA_spike_slab_noEM(
-        z: np.ndarray, ld: np.ndarray, sec_threshold: float = 600
+        z: np.ndarray,
+        ld: np.ndarray,
+        sec_threshold: float = 600,
+        tau: float = 0.04,
     ) -> dict[str, Any]:
         """The wrapper for the CARMA_spike_slab_noEM function that runs the function in a separate thread and terminates it if it takes too long.
 
@@ -26,6 +30,7 @@ class CARMA:
             z (np.ndarray): Numeric vector representing z-scores.
             ld (np.ndarray): Numeric matrix representing the linkage disequilibrium (LD) matrix.
             sec_threshold (float): The time threshold in seconds.
+            tau (float): Tuning parameter controlling the level of shrinkage of the LD matrix
 
         Returns:
             dict[str, Any]: A dictionary containing the following results:
@@ -38,7 +43,9 @@ class CARMA:
         try:
             # Execute CARMA.CARMA_spike_slab_noEM with a timeout
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(CARMA.CARMA_spike_slab_noEM, z=z, ld=ld)
+                future = executor.submit(
+                    CARMA.CARMA_spike_slab_noEM, z=z, ld=ld, tau=tau
+                )
                 result = future.result(timeout=sec_threshold)
         except concurrent.futures.TimeoutError:
             # If execution exceeds the timeout, return None
@@ -71,7 +78,7 @@ class CARMA:
             all_inner_iter (int): The number of inner iterations in each CARMA iteration.
             epsilon_threshold (float): Threshold for convergence in CARMA iterations.
             num_causal (int): Maximal number of causal variants to be selected in the final model.
-            tau (float): Tuning parameter controlling the degree of sparsity in the Spike-and-Slab prior.
+            tau (float): Tuning parameter controlling the level of shrinkage of the LD matrix.
             outlier_switch (bool): Whether to consider outlier detection in the analysis.
             outlier_BF_index (float): Bayes Factor threshold for identifying outliers.
 
@@ -604,7 +611,7 @@ class CARMA:
             num_causal (int): Maximal number of causal variants to be selected in the final model.
             outlier_switch (bool): Whether to consider outlier detection in the analysis.
             input_conditional_S_list (list[int] | None): The conditional set. Defaults to None.
-            tau (float): Tuning parameter controlling the degree of sparsity in the Spike-and-Slab prior.
+            tau (float): Tuning parameter controlling the level of shrinkage of the LD matrix.
             epsilon (float): Threshold for convergence in CARMA iterations.
             inner_all_iter (int): The number of inner iterations in each CARMA iteration.
             outlier_BF_index (float | None): Bayes Factor threshold for identifying outliers. Defaults to None.

--- a/src/gentropy/susie_finemapper.py
+++ b/src/gentropy/susie_finemapper.py
@@ -80,7 +80,7 @@ class SusieFineMapperStep:
             run_carma (bool): run CARMA, default is False
             run_sumstat_imputation (bool): run summary statistics imputation, default is False
             carma_time_limit (int): CARMA time limit, default is 600 seconds
-            carma_tau (float): CARMA tau, shrinkage parameter, default is 0.2
+            carma_tau (float): CARMA tau, shrinkage parameter
             imputed_r2_threshold (float): imputed R2 threshold, default is 0.9
             ld_score_threshold (float): LD score threshold ofr imputation, default is 5
         """
@@ -657,7 +657,7 @@ class SusieFineMapperStep:
         run_carma: bool = False,
         run_sumstat_imputation: bool = False,
         carma_time_limit: int = 600,
-        carma_tau: float = 0.2,
+        carma_tau: float = 0.04,
         imputed_r2_threshold: float = 0.8,
         ld_score_threshold: float = 4,
         sum_pips: float = 0.99,
@@ -681,7 +681,7 @@ class SusieFineMapperStep:
             run_carma (bool): run CARMA, default is False
             run_sumstat_imputation (bool): run summary statistics imputation, default is False
             carma_time_limit (int): CARMA time limit, default is 600 seconds
-            carma_tau (float): CARMA tau, shrinkage parameter, default is 0.2
+            carma_tau (float): CARMA tau, shrinkage parameter
             imputed_r2_threshold (float): imputed R2 threshold, default is 0.8
             ld_score_threshold (float): LD score threshold ofr imputation, default is 4
             sum_pips (float): the expected sum of posterior probabilities in the locus, default is 0.99 (99% credible set)
@@ -1230,7 +1230,7 @@ class SusieFineMapperStep:
         run_carma: bool = False,
         run_sumstat_imputation: bool = False,
         carma_time_limit: int = 600,
-        carma_tau: float = 0.2,
+        carma_tau: float = 0.04,
         imputed_r2_threshold: float = 0.9,
         ld_score_threshold: float = 5,
         sum_pips: float = 0.99,
@@ -1251,7 +1251,7 @@ class SusieFineMapperStep:
             run_carma (bool): run CARMA, default is False
             run_sumstat_imputation (bool): run summary statistics imputation, default is False
             carma_time_limit (int): CARMA time limit, default is 600 seconds
-            carma_tau (float): CARMA tau, shrinkage parameter, default is 0.2
+            carma_tau (float): CARMA tau, shrinkage parameter
             imputed_r2_threshold (float): imputed R2 threshold, default is 0.8
             ld_score_threshold (float): LD score threshold ofr imputation, default is 4
             sum_pips (float): the expected sum of posterior probabilities in the locus, default is 0.99 (99% credible set)

--- a/src/gentropy/susie_finemapper.py
+++ b/src/gentropy/susie_finemapper.py
@@ -58,6 +58,7 @@ class SusieFineMapperStep:
         run_carma: bool = False,
         run_sumstat_imputation: bool = False,
         carma_time_limit: int = 600,
+        carma_tau: float = 0.2,
         imputed_r2_threshold: float = 0.9,
         ld_score_threshold: float = 5,
     ) -> None:
@@ -79,6 +80,7 @@ class SusieFineMapperStep:
             run_carma (bool): run CARMA, default is False
             run_sumstat_imputation (bool): run summary statistics imputation, default is False
             carma_time_limit (int): CARMA time limit, default is 600 seconds
+            carma_tau (float): CARMA tau, shrinkage parameter, default is 0.2
             imputed_r2_threshold (float): imputed R2 threshold, default is 0.9
             ld_score_threshold (float): LD score threshold ofr imputation, default is 5
         """
@@ -113,6 +115,7 @@ class SusieFineMapperStep:
             susie_est_tausq=susie_est_tausq,
             run_carma=run_carma,
             run_sumstat_imputation=run_sumstat_imputation,
+            carma_tau=carma_tau,
             carma_time_limit=carma_time_limit,
             imputed_r2_threshold=imputed_r2_threshold,
             ld_score_threshold=ld_score_threshold,
@@ -654,6 +657,7 @@ class SusieFineMapperStep:
         run_carma: bool = False,
         run_sumstat_imputation: bool = False,
         carma_time_limit: int = 600,
+        carma_tau: float = 0.2,
         imputed_r2_threshold: float = 0.8,
         ld_score_threshold: float = 4,
         sum_pips: float = 0.99,
@@ -677,6 +681,7 @@ class SusieFineMapperStep:
             run_carma (bool): run CARMA, default is False
             run_sumstat_imputation (bool): run summary statistics imputation, default is False
             carma_time_limit (int): CARMA time limit, default is 600 seconds
+            carma_tau (float): CARMA tau, shrinkage parameter, default is 0.2
             imputed_r2_threshold (float): imputed R2 threshold, default is 0.8
             ld_score_threshold (float): LD score threshold ofr imputation, default is 4
             sum_pips (float): the expected sum of posterior probabilities in the locus, default is 0.99 (99% credible set)
@@ -721,7 +726,7 @@ class SusieFineMapperStep:
 
         if run_carma:
             carma_output = CARMA.time_limited_CARMA_spike_slab_noEM(
-                z=z_to_fm, ld=ld_to_fm, sec_threshold=carma_time_limit
+                z=z_to_fm, ld=ld_to_fm, sec_threshold=carma_time_limit, tau=carma_tau
             )
             if carma_output["Outliers"] != [] and carma_output["Outliers"] is not None:
                 GWAS_df.drop(carma_output["Outliers"], inplace=True)
@@ -1225,6 +1230,7 @@ class SusieFineMapperStep:
         run_carma: bool = False,
         run_sumstat_imputation: bool = False,
         carma_time_limit: int = 600,
+        carma_tau: float = 0.2,
         imputed_r2_threshold: float = 0.9,
         ld_score_threshold: float = 5,
         sum_pips: float = 0.99,
@@ -1245,6 +1251,7 @@ class SusieFineMapperStep:
             run_carma (bool): run CARMA, default is False
             run_sumstat_imputation (bool): run summary statistics imputation, default is False
             carma_time_limit (int): CARMA time limit, default is 600 seconds
+            carma_tau (float): CARMA tau, shrinkage parameter, default is 0.2
             imputed_r2_threshold (float): imputed R2 threshold, default is 0.8
             ld_score_threshold (float): LD score threshold ofr imputation, default is 4
             sum_pips (float): the expected sum of posterior probabilities in the locus, default is 0.99 (99% credible set)
@@ -1443,6 +1450,7 @@ class SusieFineMapperStep:
             run_carma=run_carma,
             run_sumstat_imputation=run_sumstat_imputation,
             carma_time_limit=carma_time_limit,
+            carma_tau=carma_tau,
             imputed_r2_threshold=imputed_r2_threshold,
             ld_score_threshold=ld_score_threshold,
             sum_pips=sum_pips,

--- a/src/gentropy/susie_finemapper.py
+++ b/src/gentropy/susie_finemapper.py
@@ -58,7 +58,7 @@ class SusieFineMapperStep:
         run_carma: bool = False,
         run_sumstat_imputation: bool = False,
         carma_time_limit: int = 600,
-        carma_tau: float = 0.2,
+        carma_tau: float = 0.15,
         imputed_r2_threshold: float = 0.9,
         ld_score_threshold: float = 5,
     ) -> None:


### PR DESCRIPTION
## ✨ Context
This PR fixes the bug with CARMA reported by Kirill (NaN in probabilities). 
<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement
It adds the parameter to FineMapper. The error turned out to be a problem with LD and increasing this parameter helps to overcome it reducing the sensitivity of the method. 

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
