### PR TITLE
refactor: generalise the harmonisation pipeline

### DIFF
--- a/src/gentropy/common/harmonise.py
+++ b/src/gentropy/common/harmonise.py
@@ -72,16 +72,24 @@ def harmonise_summary_stats(
                 f.col("chromosome") == "23", "X"
             ).otherwise(f.col("chromosome"))
         )
+    )
+    if colname_info:
         # Harmonise, 2: Filter out low INFO rows.
-        .filter(f.col(colname_info) >= 0.8)
+        df = df.filter(f.col(colname_info) >= 0.8)
+    if colname_a1freq:
         # Harmonise, 3: Filter out low frequency rows.
-        .withColumn(
-            "MAF",
-            f.when(f.col(colname_a1freq) < 0.5, f.col(colname_a1freq))
-            .otherwise(1 - f.col(colname_a1freq))
+        df = (
+            df
+            .withColumn(
+                "MAF",
+                f.when(f.col(colname_a1freq) < 0.5, f.col(colname_a1freq))
+                .otherwise(1 - f.col(colname_a1freq))
+            )
+            .filter(f.col("MAF") >= 0.0001)
+            .drop("MAF")
         )
-        .filter(f.col("MAF") >= 0.0001)
-        .drop("MAF")
+    df = (
+        df
         # Harmonise, 4: Assign variant types.
         .withColumn(
             "variant_type",

--- a/src/gentropy/common/harmonise.py
+++ b/src/gentropy/common/harmonise.py
@@ -1,0 +1,154 @@
+"""Variant harmonisation utilities."""
+
+import pyspark.sql.functions as f
+import pyspark.sql.types as t
+from pyspark.sql import DataFrame, SparkSession
+
+from gentropy.common.spark_helpers import neglog_pvalue_to_mantissa_and_exponent
+
+
+def harmonise_summary_stats(
+    spark: SparkSession,
+    raw_summary_stats_path: str,
+    tmp_variant_annotation_path: str,
+    chromosome: str
+) -> DataFrame:
+    """Ingest and harmonise the summary stats.
+
+    1. Rename chromosome 23 to X.
+    2. Filter out low INFO rows.
+    3. Filter out low frequency rows.
+    4. Assign variant types.
+    5. Create variant ID for joining the variant annotation dataset.
+    6. Join with the Variant Annotation dataset.
+    7. Drop bad quality variants.
+
+    Args:
+        spark (SparkSession): Spark session object.
+        raw_summary_stats_path (str): Input raw summary stats path.
+        tmp_variant_annotation_path (str): Input variant annotation dataset path.
+        chromosome (str): Which chromosome to process.
+
+    Returns:
+        DataFrame: A harmonised summary stats dataframe.
+    """
+    # Read the precomputed variant annotation dataset.
+    va_df = (
+        spark
+        .read
+        .parquet(tmp_variant_annotation_path)
+        .filter(f.col("vaChromosome") == ("X" if chromosome == "23" else chromosome))
+        .persist()
+    )
+
+    # Read and process the summary stats dataset.
+    df = (
+        spark
+        .read
+        .parquet(raw_summary_stats_path)
+        .filter(f.col("chromosome") == chromosome)
+        # Harmonise, 1: Rename chromosome 23 to X.
+        .withColumn(
+            "chromosome",
+            f.when(
+                f.col("chromosome") == "23", "X"
+            ).otherwise(f.col("chromosome"))
+        )
+        # Harmonise, 2: Filter out low INFO rows.
+        .filter(f.col("INFO") >= 0.8)
+        # Harmonise, 3: Filter out low frequency rows.
+        .withColumn(
+            "MAF",
+            f.when(f.col("A1FREQ") < 0.5, f.col("A1FREQ"))
+            .otherwise(1 - f.col("A1FREQ"))
+        )
+        .filter(f.col("MAF") >= 0.0001)
+        .drop("MAF")
+        # Harmonise, 4: Assign variant types.
+        .withColumn(
+            "variant_type",
+            f.when(
+                (f.length("ALLELE0") == 1) & (f.length("ALLELE1") == 1),
+                f.when(
+                    ((f.col("ALLELE0") == "A") & (f.col("ALLELE1") == "T")) |
+                    ((f.col("ALLELE0") == "T") & (f.col("ALLELE1") == "A")) |
+                    ((f.col("ALLELE0") == "G") & (f.col("ALLELE1") == "C")) |
+                    ((f.col("ALLELE0") == "C") & (f.col("ALLELE1") == "G")),
+                    "snp_c"
+                )
+                .otherwise(
+                    "snp_n"
+                )
+            )
+            .otherwise(
+                "indel"
+            )
+        )
+        # Harmonise, 5: Create variant ID for joining the variant annotation dataset.
+        .withColumn(
+            "GENPOS",
+            f.col("GENPOS").cast("integer")
+        )
+        .withColumn(
+            "summary_stats_id",
+            f.concat_ws(
+                "_",
+                f.col("chromosome"),
+                f.col("GENPOS"),
+                f.col("ALLELE0"),
+                f.col("ALLELE1")
+            )
+        )
+    )
+    # Harmonise, 6: Join with the Variant Annotation dataset.
+    df = (
+        df
+        .join(va_df, (df["chromosome"] == va_df["vaChromosome"]) & (df["summary_stats_id"] == va_df["summary_stats_id"]), "inner")
+        .drop("vaChromosome", "summary_stats_id")
+        .withColumn(
+            "effectAlleleFrequencyFromSource",
+            f.when(
+                f.col("direction") == "direct",
+                f.col("A1FREQ").cast("float")
+            ).otherwise(1 - f.col("A1FREQ").cast("float"))
+        )
+        .withColumn(
+            "beta",
+            f.when(
+                f.col("direction") == "direct",
+                f.col("BETA").cast("double")
+            ).otherwise(-f.col("BETA").cast("double"))
+        )
+    )
+    df = (
+        # Harmonise, 7: Drop bad quality variants.
+        df
+        .filter(
+            ~ ((f.col("variant_type") == "snp_c") & (f.col("direction") == "flip"))
+        )
+    )
+
+    # Prepare the fields according to schema.
+    df = (
+        df
+        .select(
+            f.col("studyId"),
+            f.col("chromosome"),
+            f.col("variantId"),
+            f.col("beta"),
+            f.col("GENPOS").cast(t.IntegerType()).alias("position"),
+            # Parse p-value into mantissa and exponent.
+            *neglog_pvalue_to_mantissa_and_exponent(f.col("LOG10P").cast(t.DoubleType())),
+            # Add standard error and sample size information.
+            f.col("SE").cast("double").alias("standardError"),
+            f.col("N").cast("integer").alias("sampleSize"),
+        )
+        # Drop rows which don't have proper position or beta value.
+        .filter(
+            f.col("position").cast(t.IntegerType()).isNotNull()
+            & (f.col("beta") != 0)
+        )
+    )
+
+    # Return the dataframe.
+    return df

--- a/src/gentropy/common/harmonise.py
+++ b/src/gentropy/common/harmonise.py
@@ -35,7 +35,7 @@ def harmonise_summary_stats(
     Args:
         spark (SparkSession): Spark session object.
         raw_summary_stats_path (str): Input raw summary stats path.
-        tmp_variant_annotation_path (str): Input variant annotation dataset path.
+        tmp_variant_annotation_path (str): Path to the Variant Annotation dataset which has been further prepared and processed by the per_chromosome module (previous PR in the chain) to speed up the joins in the harmonisation phase. It includes all variants in both the direct (A0/A1) and reverse (A1/A0) orientations, so that the direction of the variant can be easily determined on joining.
         chromosome (str): Which chromosome to process.
         colname_position (str): Column name for position.
         colname_allele0 (str): Column name for allele0.
@@ -91,6 +91,10 @@ def harmonise_summary_stats(
     df = (
         df
         # Harmonise, 4: Assign variant types.
+        # There are three possible variant types:
+        # 1. `snp_c` means an SNP converting a base into its complementary base: A<>T or G><C.
+        # 2. `snp_n` means any other SNP where the length of each allele is still exactly 1.
+        # 3. `indel` means any other variant where the length of at least one allele is greater than 1.
         .withColumn(
             "variant_type",
             f.when(

--- a/src/gentropy/datasource/ukb_ppp_eur/summary_stats.py
+++ b/src/gentropy/datasource/ukb_ppp_eur/summary_stats.py
@@ -33,7 +33,21 @@ class UkbPppEurSummaryStats:
         Returns:
             SummaryStatistics: Processed summary statistics dataset for a given chromosome.
         """
-        df = harmonise_summary_stats(spark, raw_summary_stats_path, tmp_variant_annotation_path, chromosome)
+        df = harmonise_summary_stats(
+            spark,
+            raw_summary_stats_path,
+            tmp_variant_annotation_path,
+            chromosome,
+            colname_position="GENPOS",
+            colname_allele0="ALLELE0",
+            colname_allele1="ALLELE1",
+            colname_a1freq="A1FREQ",
+            colname_info="INFO",
+            colname_beta="BETA",
+            colname_se="SE",
+            colname_mlog10p="LOG10P",
+            colname_n="N",
+        )
 
         # Create the summary statistics object.
         return SummaryStatistics(

--- a/src/gentropy/datasource/ukb_ppp_eur/summary_stats.py
+++ b/src/gentropy/datasource/ukb_ppp_eur/summary_stats.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import pyspark.sql.functions as f
-import pyspark.sql.types as t
 from pyspark.sql import SparkSession
 
-from gentropy.common.spark_helpers import neglog_pvalue_to_mantissa_and_exponent
+from gentropy.common.harmonise import harmonise_summary_stats
 from gentropy.dataset.summary_statistics import SummaryStatistics
 
 
@@ -26,14 +24,6 @@ class UkbPppEurSummaryStats:
     ) -> SummaryStatistics:
         """Ingest and harmonise all summary stats for UKB PPP (EUR) data.
 
-        1. Rename chromosome 23 to X.
-        2. Filter out low INFO rows.
-        3. Filter out low frequency rows.
-        4. Assign variant types.
-        5. Create variant ID for joining the variant annotation dataset.
-        6. Join with the Variant Annotation dataset.
-        7. Drop bad quality variants.
-
         Args:
             spark (SparkSession): Spark session object.
             raw_summary_stats_path (str): Input raw summary stats path.
@@ -43,123 +33,7 @@ class UkbPppEurSummaryStats:
         Returns:
             SummaryStatistics: Processed summary statistics dataset for a given chromosome.
         """
-        # Read the precomputed variant annotation dataset.
-        va_df = (
-            spark
-            .read
-            .parquet(tmp_variant_annotation_path)
-            .filter(f.col("vaChromosome") == ("X" if chromosome == "23" else chromosome))
-            .persist()
-        )
-
-        # Read and process the summary stats dataset.
-        df = (
-            spark
-            .read
-            .parquet(raw_summary_stats_path)
-            .filter(f.col("chromosome") == chromosome)
-            # Harmonise, 1: Rename chromosome 23 to X.
-            .withColumn(
-                "chromosome",
-                f.when(
-                    f.col("chromosome") == "23", "X"
-                ).otherwise(f.col("chromosome"))
-            )
-            # Harmonise, 2: Filter out low INFO rows.
-            .filter(f.col("INFO") >= 0.8)
-            # Harmonise, 3: Filter out low frequency rows.
-            .withColumn(
-                "MAF",
-                f.when(f.col("A1FREQ") < 0.5, f.col("A1FREQ"))
-                .otherwise(1 - f.col("A1FREQ"))
-            )
-            .filter(f.col("MAF") >= 0.0001)
-            .drop("MAF")
-            # Harmonise, 4: Assign variant types.
-            .withColumn(
-                "variant_type",
-                f.when(
-                    (f.length("ALLELE0") == 1) & (f.length("ALLELE1") == 1),
-                    f.when(
-                        ((f.col("ALLELE0") == "A") & (f.col("ALLELE1") == "T")) |
-                        ((f.col("ALLELE0") == "T") & (f.col("ALLELE1") == "A")) |
-                        ((f.col("ALLELE0") == "G") & (f.col("ALLELE1") == "C")) |
-                        ((f.col("ALLELE0") == "C") & (f.col("ALLELE1") == "G")),
-                        "snp_c"
-                    )
-                    .otherwise(
-                        "snp_n"
-                    )
-                )
-                .otherwise(
-                    "indel"
-                )
-            )
-            # Harmonise, 5: Create variant ID for joining the variant annotation dataset.
-            .withColumn(
-                "GENPOS",
-                f.col("GENPOS").cast("integer")
-            )
-            .withColumn(
-                "ukb_ppp_id",
-                f.concat_ws(
-                    "_",
-                    f.col("chromosome"),
-                    f.col("GENPOS"),
-                    f.col("ALLELE0"),
-                    f.col("ALLELE1")
-                )
-            )
-        )
-        # Harmonise, 6: Join with the Variant Annotation dataset.
-        df = (
-            df
-            .join(va_df, (df["chromosome"] == va_df["vaChromosome"]) & (df["ukb_ppp_id"] == va_df["ukb_ppp_id"]), "inner")
-            .drop("vaChromosome", "ukb_ppp_id")
-            .withColumn(
-                "effectAlleleFrequencyFromSource",
-                f.when(
-                    f.col("direction") == "direct",
-                    f.col("A1FREQ").cast("float")
-                ).otherwise(1 - f.col("A1FREQ").cast("float"))
-            )
-            .withColumn(
-                "beta",
-                f.when(
-                    f.col("direction") == "direct",
-                    f.col("BETA").cast("double")
-                ).otherwise(-f.col("BETA").cast("double"))
-            )
-        )
-        df = (
-            # Harmonise, 7: Drop bad quality variants.
-            df
-            .filter(
-                ~ ((f.col("variant_type") == "snp_c") & (f.col("direction") == "flip"))
-            )
-        )
-
-        # Prepare the fields according to schema.
-        df = (
-            df
-            .select(
-                f.col("studyId"),
-                f.col("chromosome"),
-                f.col("variantId"),
-                f.col("beta"),
-                f.col("GENPOS").cast(t.IntegerType()).alias("position"),
-                # Parse p-value into mantissa and exponent.
-                *neglog_pvalue_to_mantissa_and_exponent(f.col("LOG10P").cast(t.DoubleType())),
-                # Add standard error and sample size information.
-                f.col("SE").cast("double").alias("standardError"),
-                f.col("N").cast("integer").alias("sampleSize"),
-            )
-            # Drop rows which don't have proper position or beta value.
-            .filter(
-                f.col("position").cast(t.IntegerType()).isNotNull()
-                & (f.col("beta") != 0)
-            )
-        )
+        df = harmonise_summary_stats(spark, raw_summary_stats_path, tmp_variant_annotation_path, chromosome)
 
         # Create the summary statistics object.
         return SummaryStatistics(


### PR DESCRIPTION
## ✨ Context
This is the first PR in a series of three to implement FinnGen UKB meta-analysis ingestion.

Previously, per-chromosome processing and harmonisation routines were implemented specifically for UKB PPP data.

This series of PRs generalises those routeines to make them reusable, and builds FinnGen UKB meta-analysis ingestion on top of those changes.

## 🛠 What does this PR implement
Generalise the harmonisation pipeline:
* Move into a separate module
* Make column names configurable
* Make some column names optional

## 🙈 Missing
N/A

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
