### PR TITLE
feat(validation): adding credible set variant validation

### DIFF
--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pyspark.sql.functions as f
-from pyspark.sql.types import FloatType, StringType
+from pyspark.sql.types import ArrayType, FloatType, StringType
 
 from gentropy.common.schemas import parse_spark_schema
 from gentropy.common.spark_helpers import (
@@ -18,6 +18,7 @@ from gentropy.common.spark_helpers import (
 from gentropy.common.utils import get_logsum, parse_region
 from gentropy.dataset.dataset import Dataset
 from gentropy.dataset.study_locus_overlap import StudyLocusOverlap
+from gentropy.dataset.variant_index import VariantIndex
 from gentropy.method.clump import LDclumping
 
 if TYPE_CHECKING:
@@ -47,6 +48,7 @@ class StudyLocusQualityCheck(Enum):
         FAILED_STUDY (str): Flagging study loci if the study has failed QC
         MISSING_STUDY (str): Flagging study loci if the study is not found in the study index as a reference
         DUPLICATED_STUDYLOCUS_ID (str): Study-locus identifier is not unique.
+        INVALID_VARIANT_IDENTIFIER (str): Flagging study locus where any variant in the locus was not found in the variant index
     """
 
     SUBSIGNIFICANT_FLAG = "Subsignificant p-value"
@@ -65,6 +67,7 @@ class StudyLocusQualityCheck(Enum):
     FAILED_STUDY = "Study has failed quality controls"
     MISSING_STUDY = "Study not found in the study index"
     DUPLICATED_STUDYLOCUS_ID = "Non-unique study locus identifier"
+    INVALID_VARIANT_IDENTIFIER = "Locus variant identifier not found in variant index"
 
 
 class CredibleInterval(Enum):
@@ -137,6 +140,65 @@ class StudyLocus(Dataset):
                     ),
                 )
                 .drop("study_studyId", "study_qualityControls")
+            ),
+            _schema=self.get_schema(),
+        )
+
+    def validate_variant_identifiers(
+        self: StudyLocus, variant_index: VariantIndex
+    ) -> StudyLocus:
+        """Flagging study loci with invalid variant identifiers.
+
+        Args:
+            variant_index (VariantIndex): Variant index to resolve variant identifiers.
+
+        Returns:
+            StudyLocus: Updated study locus with quality control flags.
+        """
+        # QC column might not be present in the variant index schema, so we have to be ready to handle it:
+        qc_select_expression = (
+            f.col("qualityControls")
+            if "qualityControls" in self.df.columns
+            else f.lit(None).cast(ArrayType(StringType()))
+        )
+
+        # Find out which study loci have variants not in the variant index:
+        flag = (
+            self.df
+            # Exploding locus:
+            .select("studyLocusId", f.explode("locus").alias("locus"))
+            .select("studyLocusId", "locus.variantId")
+            # Join with variant index variants:
+            .join(
+                variant_index.df.select(
+                    "variantId", f.lit(True).alias("inVariantIndex")
+                ),
+                on="variantId",
+                how="left",
+            )
+            # Flagging variants not in the variant index:
+            .withColumn("inVariantIndex", f.col("inVariantIndex").isNotNull())
+            # Flagging study loci with variants not in the variant index:
+            .groupBy("studyLocusId")
+            .agg(f.collect_set("inVariantIndex").alias("inVariantIndex"))
+            .select(
+                "studyLocusId",
+                f.array_contains("inVariantIndex", False).alias("toFlag"),
+            )
+        )
+
+        return StudyLocus(
+            _df=(
+                self.df.join(flag, on="studyLocusId", how="left")
+                .withColumn(
+                    "qualityControls",
+                    self.update_quality_flag(
+                        qc_select_expression,
+                        f.col("toFlag"),
+                        StudyLocusQualityCheck.INVALID_VARIANT_IDENTIFIER,
+                    ),
+                )
+                .drop("toFlag")
             ),
             _schema=self.get_schema(),
         )


### PR DESCRIPTION
Business logic + testing for flagging study loci if any tagging variant is not in the variant index. This logic assumes the lead variant is **always** in the locus object.