### PR TITLE
docs: update broken refs

### DIFF
--- a/src/gentropy/dataset/summary_statistics.py
+++ b/src/gentropy/dataset/summary_statistics.py
@@ -90,7 +90,7 @@ class SummaryStatistics(Dataset):
     ) -> StudyLocus:
         """Generate study-locus from summary statistics using locus-breaker clumping method with locus boundaries.
 
-        For more info, see [`locus_breaker`][gentropy.method.locus_breaker_clumping.locus_breaker]
+        For more info, see [`locus_breaker`][gentropy.method.locus_breaker_clumping.LocusBreakerClumping]
 
         Args:
             baseline_pvalue_cutoff (float, optional): Baseline significance we consider for the locus.

--- a/src/gentropy/method/sumstat_imputation.py
+++ b/src/gentropy/method/sumstat_imputation.py
@@ -24,7 +24,7 @@ class SummaryStatisticsImputation:
         Args:
             z_scores_known (np.ndarray): the vector of known Z scores
             ld_matrix_known (np.ndarray) : the matrix of known LD correlations
-            ld_matrix_known_missing (np.ndarray): LD matrix of known SNPs with other unknown SNPs in large matrix (similar to ld[unknowns, :][:,known])
+            ld_matrix_known_missing (np.ndarray): LD matrix of known SNPs with other unknown SNPs in large matrix (similar to `ld[unknowns, :][:,known]`)
             lamb (float): size of the small value added to the diagonal of the covariance matrix before inversion. Defaults to 0.01.
             rtol (float): threshold to filter eigenvectos by its eigenvalue. It makes an inversion biased but much more numerically robust. Default to 0.01.
 


### PR DESCRIPTION
Some refs were broken and mkdocs was throwing WARNINGS. This fixes it.

We could activate the ["strict" mode](https://github.com/opentargets/gentropy/blob/6ede7363c683d0955edafc647c9d13b2baf17fc7/tests/gentropy/docs/test_build.py#L19) on the mkdocs test if we want to prevent this in the future. For some reason, I thought this was too harsh in the past but maybe we could reconsider. I'll leave it up to you @project-defiant 