### PR TITLE
perf: quickly build a Docker image for every branch

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -39,21 +39,21 @@ jobs:
         run: |-
           gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
-      # - name: Build and push gentropy image (AMD64)
-      #   uses: docker/build-push-action@v6
-      #   with:
-      #     platforms: linux/amd64
-      #     push: true
-      #     tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
-      #     context: .
+      - name: Build and push gentropy image (AMD64)
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
+          context: .
 
-      # - name: Build and push gentropy image (ARM64)
-      #   uses: docker/build-push-action@v6
-      #   with:
-      #     platforms: linux/arm64
-      #     push: true
-      #     tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
-      #     context: .
+      - name: Build and push gentropy image (ARM64)
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/arm64
+          push: true
+          tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
+          context: .
 
       - name: Build and push VEP image (AMD64)
         uses: docker/build-push-action@v6

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -3,7 +3,7 @@ name: Build and Push to Artifact Registry
 "on":
   push:
     branches: ["*"]
-    tags: ["v*"]
+    tags: ["*"]
 
 env:
   PROJECT_ID: open-targets-genetics-dev

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -50,7 +50,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push gentropy image
-        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/heads/v')
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
@@ -59,7 +59,7 @@ jobs:
           context: .
 
       - name: Build and push VEP image
-        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/heads/v')
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -46,6 +46,8 @@ jobs:
           push: true
           tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and push VEP image
         uses: docker/build-push-action@v6
@@ -55,3 +57,5 @@ jobs:
           tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/custom_ensembl_vep:${{ github.ref_name }}"
           context: .
           file: "src/vep/Dockerfile"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -2,7 +2,7 @@ name: Build and Push to Artifact Registry
 
 "on":
   push:
-    branches: ["dev", "tskir-cache-docker"]
+    branches: ["*"]
     tags: ["v*"]
 
 env:
@@ -39,35 +39,30 @@ jobs:
         run: |-
           gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
-      - name: Build and push gentropy image (AMD64)
+      - name: Quick Docker build (gentropy only, AMD64 only, with layer cache)
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64
           push: true
           tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Build and push gentropy image (ARM64)
+      - name: Build and push gentropy image
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/heads/v')
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
           context: .
 
-      - name: Build and push VEP image (AMD64)
+      - name: Build and push VEP image
+        if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/heads/v')
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64
-          push: true
-          tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/custom_ensembl_vep:${{ github.ref_name }}"
-          context: .
-          file: "src/vep/Dockerfile"
-
-      - name: Build and push VEP image (ARM64)
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/custom_ensembl_vep:${{ github.ref_name }}"
           context: .

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -39,26 +39,35 @@ jobs:
         run: |-
           gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
-      - name: Build and push gentropy image (AMD64)
+      # - name: Build and push gentropy image (AMD64)
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     platforms: linux/amd64
+      #     push: true
+      #     tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
+      #     context: .
+
+      # - name: Build and push gentropy image (ARM64)
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     platforms: linux/arm64
+      #     push: true
+      #     tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
+      #     context: .
+
+      - name: Build and push VEP image (AMD64)
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64
           push: true
-          tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
+          tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/custom_ensembl_vep:${{ github.ref_name }}"
           context: .
+          file: "src/vep/Dockerfile"
 
-      - name: Build and push gentropy image (ARM64)
+      - name: Build and push VEP image (ARM64)
         uses: docker/build-push-action@v6
         with:
           platforms: linux/arm64
-          push: true
-          tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
-          context: .
-
-      - name: Build and push VEP image (both platforms)
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/custom_ensembl_vep:${{ github.ref_name }}"
           context: .

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -39,23 +39,27 @@ jobs:
         run: |-
           gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
-      - name: Build and push gentropy image
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
-          context: .
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push VEP image
+      - name: Build and push gentropy image (AMD64)
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64
           push: true
+          tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
+          context: .
+
+      - name: Build and push gentropy image (ARM64)
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/arm64
+          push: true
+          tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/gentropy:${{ github.ref_name }}"
+          context: .
+
+      - name: Build and push VEP image (both platforms)
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
           tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/custom_ensembl_vep:${{ github.ref_name }}"
           context: .
           file: "src/vep/Dockerfile"
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -62,7 +62,7 @@ jobs:
         if: github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: "${{ env.GAR_LOCATION }}/${{ env.REPOSITORY }}/custom_ensembl_vep:${{ github.ref_name }}"
           context: .

--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -2,7 +2,7 @@ name: Build and Push to Artifact Registry
 
 "on":
   push:
-    branches: ["dev"]
+    branches: ["dev", "tskir-cache-docker"]
     tags: ["v*"]
 
 env:


### PR DESCRIPTION
## ✨ Context
There are two problems with Docker builds:
* They take about 11 minutes per commit;
* They only happen for the `dev` branch and `v*` tags.

It is desirable to automatically build the image for other branches, so that a version in development could be run for example on Google Batch. However, with 11 minutes per commit it's not very convenient.

## 🛠 What does this PR implement
Add a step to quickly build a Docker image for every branch, which means:
* Only build the main gentropy image;
* Only do it for the AMD64 architecture required for Google cloud;
* Use maximum layer caching through GHA.

With this change, build takes around 1–2 minutes per commit (depending on whether dependencies were changed or not) instead of 11. This is now trivial to run for every commit of every branch.

The full builds, which include ARM64 infrastructure and the VEP image, are still only ran for the dev branch and v* tags, as before.

## 🙈 Missing
N/A.

## 🚦 Before submitting
- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
