### PR TITLE
feat: flag all top-hits from GWAS catalog curation

### DIFF
--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -48,8 +48,9 @@ class StudyLocusQualityCheck(Enum):
         NOT_QUALIFYING_LD_BLOCK (str): LD block does not contain variants at the required R^2 threshold
         FAILED_STUDY (str): Flagging study loci if the study has failed QC
         MISSING_STUDY (str): Flagging study loci if the study is not found in the study index as a reference
-        DUPLICATED_STUDYLOCUS_ID (str): Study-locus identifier is not unique.
+        DUPLICATED_STUDYLOCUS_ID (str): Study-locus identifier is not unique
         INVALID_VARIANT_IDENTIFIER (str): Flagging study loci where identifier of any tagging variant was not found in the variant index
+        TOP_HIT (str): Study locus from curated top hit
         IN_MHC (str): Flagging study loci in the MHC region
     """
 
@@ -73,6 +74,7 @@ class StudyLocusQualityCheck(Enum):
         "Some variant identifiers of this locus were not found in variant index"
     )
     IN_MHC = "MHC region"
+    TOP_HIT = "Study locus from curated top hit"
 
 
 class CredibleInterval(Enum):

--- a/src/gentropy/datasource/gwas_catalog/associations.py
+++ b/src/gentropy/datasource/gwas_catalog/associations.py
@@ -1212,6 +1212,24 @@ class StudyLocusGWASCatalog(StudyLocus):
         )
         return self
 
+    def qc_flag_all_tophits(self: StudyLocusGWASCatalog) -> StudyLocusGWASCatalog:
+        """Flag all associations as top hits.
+
+        Returns:
+            StudyLocusGWASCatalog: Updated study locus.
+        """
+        return StudyLocusGWASCatalog(
+            _df=self._df.withColumn(
+                "qualityControls",
+                StudyLocus.update_quality_flag(
+                    f.col("qualityControls"),
+                    f.lit(True),
+                    StudyLocusQualityCheck.TOP_HIT,
+                ),
+            ),
+            _schema=StudyLocusGWASCatalog.get_schema(),
+        )
+
     def apply_inclusion_list(
         self: StudyLocusGWASCatalog, inclusion_list: DataFrame
     ) -> StudyLocusGWASCatalog:

--- a/src/gentropy/datasource/gwas_catalog/study_splitter.py
+++ b/src/gentropy/datasource/gwas_catalog/study_splitter.py
@@ -132,5 +132,7 @@ class GWASCatalogStudySplitter:
                 st_ass.select(
                     "updatedStudyId", "studyId", "subStudyDescription"
                 ).distinct()
-            ).qc_ambiguous_study(),
+            )
+            .qc_ambiguous_study()
+            .qc_flag_all_tophits(),
         )

--- a/tests/gentropy/datasource/gwas_catalog/test_gwas_catalog_associations.py
+++ b/tests/gentropy/datasource/gwas_catalog/test_gwas_catalog_associations.py
@@ -77,3 +77,12 @@ def test_map_variants_to_variant_index(
         ),
         DataFrame,
     )
+
+
+def test_qc_flag_all_tophits(
+    mock_study_locus_gwas_catalog: StudyLocusGWASCatalog,
+) -> None:
+    """Test qc flag all top hits."""
+    assert isinstance(
+        mock_study_locus_gwas_catalog.qc_flag_all_tophits(), StudyLocusGWASCatalog
+    )


### PR DESCRIPTION
Closes opentargets/issues#3487

The only tricky decision here was where to place the QC flagging. I did it at the very end of the pipeline as `StudyLocusGWASCatalog` specific logic.