### PR TITLE
fix: bug in neglog_pvalue_to_mantissa_and_exponent

### DIFF
--- a/src/gentropy/common/spark_helpers.py
+++ b/src/gentropy/common/spark_helpers.py
@@ -270,13 +270,13 @@ def neglog_pvalue_to_mantissa_and_exponent(p_value: Column) -> tuple[Column, Col
         +--------+--------------+--------------+
         |negLogPv|pValueMantissa|pValueExponent|
         +--------+--------------+--------------+
-        |    4.56|     3.6307805|            -5|
-        | 2109.23|     1.6982436|         -2110|
+        |    4.56|     2.7542286|            -5|
+        | 2109.23|     5.8884363|         -2110|
         +--------+--------------+--------------+
         <BLANKLINE>
     """
     exponent: Column = f.ceil(p_value)
-    mantissa: Column = f.pow(f.lit(10), (p_value - exponent + f.lit(1)))
+    mantissa: Column = f.pow(f.lit(10), (exponent - p_value))
 
     return (
         mantissa.cast(t.FloatType()).alias("pValueMantissa"),
@@ -675,7 +675,6 @@ def safe_array_union(
     return f.when(a.isNotNull() & b.isNotNull(), f.array_union(a, b)).otherwise(
         f.coalesce(a, b)
     )
-
 
 
 def sort_array_struct_by_columns(column: Column, fields_order: list[str]) -> Column:


### PR DESCRIPTION
## ✨ Context
There was a bug in spark_helpers in neglog_pvalue_to_mantissa_and_exponent - incorrect formula. Was spotted due to discrepancies in susie.
<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
