### PR TITLE
feat: out sample LD qc reason

### DIFF
--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -86,6 +86,7 @@ class StudyLocusQualityCheck(Enum):
     )
     TOP_HIT = "Study locus from curated top hit"
     EXPLAINED_BY_SUSIE = "Study locus in region explained by a SuSiE credible set"
+    OUT_OF_SAMPLE_LD = "Study locus finemapped without in-sample LD reference"
 
 
 class CredibleInterval(Enum):


### PR DESCRIPTION
Just adding the credible set QC reason, so it can be leveraged in the future for adding the logic or mocking the data.

This flag specifies that a credible set has been generated without in-sample LD

Related to opentargets/issues#3555