### PR TITLE
chore: drop redundant parameter from sumstat qc step

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -439,7 +439,6 @@ class GWASQCStep(StepConfig):
 
     gwas_path: str = MISSING
     output_path: str = MISSING
-    studyid: str = MISSING
     pval_threshold: float = MISSING
     _target_: str = "gentropy.sumstat_qc_step.SummaryStatisticsQCStep"
 

--- a/src/gentropy/sumstat_qc_step.py
+++ b/src/gentropy/sumstat_qc_step.py
@@ -15,7 +15,6 @@ class SummaryStatisticsQCStep:
         session: Session,
         gwas_path: str,
         output_path: str,
-        studyid: str,
         pval_threshold: float = 1e-8,
     ) -> None:
         """Calculating quality control metrics on the provided GWAS study.
@@ -24,7 +23,6 @@ class SummaryStatisticsQCStep:
             session (Session): Spark session
             gwas_path (str): Path to the GWAS summary statistics.
             output_path (str): Output path for the QC results.
-            studyid (str): Study ID for the QC.
             pval_threshold (float): P-value threshold for the QC. Default is 1e-8.
 
         """
@@ -35,5 +33,5 @@ class SummaryStatisticsQCStep:
                 gwas=gwas, limit=100_000_000, pval_threshold=pval_threshold
             )
             .write.mode(session.write_mode)
-            .parquet(output_path + "/qc_results_" + studyid)
+            .parquet(output_path)
         )


### PR DESCRIPTION
## ✨ Context

Currently `study_id` is a required parameter for running the `summary_statistics_qc` step. This is not ideal, as when running in bulk, we can not specify which study_id should be used to create the qc output path. 

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

- [x] Removal of `study_id` parameter from the `summary_statistics_qc` step
- [x] Removal of static `/qc_results_` that is appended in the step output

The path to QC should be fully configurable, without it's part being hardcoded.
 
<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
