### PR TITLE
revert: no longer rescuing variants not in LD matrix when overlapping with SuSiE

### DIFF
--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -279,7 +279,8 @@ class StudyLocus(Dataset):
             df = self.df.withColumn(
                 qc_colname,
                 create_empty_column_if_not_exists(
-                    qc_colname, get_struct_field_schema(StudyLocus.get_schema(), qc_colname)
+                    qc_colname,
+                    get_struct_field_schema(StudyLocus.get_schema(), qc_colname),
                 ),
             )
         return StudyLocus(
@@ -1046,12 +1047,7 @@ class StudyLocus(Dataset):
                         # credible set in SuSiE overlapping region
                         f.col("inSuSiE")
                         # credible set not based on SuSiE
-                        & (f.col("finemappingMethod") != "SuSiE-inf")
-                        # credible set not already flagged as unresolved LD
-                        & ~f.array_contains(
-                            f.col("qualityControls"),
-                            StudyLocusQualityCheck.UNRESOLVED_LD.value,
-                        ),
+                        & (f.col("finemappingMethod") != "SuSiE-inf"),
                         StudyLocusQualityCheck.EXPLAINED_BY_SUSIE,
                     ),
                 )

--- a/tests/gentropy/dataset/test_study_locus.py
+++ b/tests/gentropy/dataset/test_study_locus.py
@@ -985,7 +985,7 @@ class TestStudyLocusSuSiERedundancyFlagging:
             [{"variantId": "X_3_A_A"}, {"variantId": "X_5_A_A"}],
             [],
         ),
-        # NOT to be flagged (Unresolved LD)
+        # To be flagged (Unresolved LD flag on it)
         (
             "5",
             "v5",
@@ -1080,4 +1080,4 @@ class TestStudyLocusSuSiERedundancyFlagging:
                 )
             )
             .count()
-        ) == 2
+        ) == 3


### PR DESCRIPTION
As discussed with @addramir, we will want to discard all credible sets overlapping with SuSiE regions no matter whether we have LD information or no.

(Before we were rescuing PICS hits when no-LD is available)

We are going for the most conservative option for now.