### PR TITLE
fix: adding single point statistics to pics loci

### DIFF
--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -412,6 +412,7 @@ class StudyLocus(Dataset):
             .select(
                 f.col("left.studyLocusId").alias("leftStudyLocusId"),
                 f.col("right.studyLocusId").alias("rightStudyLocusId"),
+                f.col("right.studyType").alias("rightStudyType"),
                 f.col("left.chromosome").alias("chromosome"),
             )
             .distinct()
@@ -452,7 +453,6 @@ class StudyLocus(Dataset):
             f.col("chromosome"),
             f.col("tagVariantId"),
             f.col("studyLocusId").alias("rightStudyLocusId"),
-            f.col("studyType").alias("rightStudyType"),
             *[f.col(col).alias(f"right_{col}") for col in stats_cols],
         ).join(peak_overlaps, on=["chromosome", "rightStudyLocusId"], how="inner")
 
@@ -464,6 +464,7 @@ class StudyLocus(Dataset):
                 "rightStudyLocusId",
                 "leftStudyLocusId",
                 "tagVariantId",
+                "rightStudyType",
             ],
             how="outer",
         ).select(


### PR DESCRIPTION
## ✨ Context

Because the tag variants in the PICS-ed loci aren't coming from summary statistics, there is no single point statistics for them, not even for the lead variant. This PR updates these fields inside the locus object IF the tag variant is the lead variant.