### PR TITLE
feat: enhance variant index partitioning

### DIFF
--- a/src/gentropy/variant_index.py
+++ b/src/gentropy/variant_index.py
@@ -59,8 +59,7 @@ class VariantIndexStep:
                     col("variantId"), col("chromosome"), col("position")
                 ),
             )
-            .write.partitionBy("chromosome")
-            .mode(session.write_mode)
+            .write.mode(session.write_mode)
             .parquet(variant_index_path)
         )
 

--- a/src/gentropy/variant_index.py
+++ b/src/gentropy/variant_index.py
@@ -59,6 +59,8 @@ class VariantIndexStep:
                     col("variantId"), col("chromosome"), col("position")
                 ),
             )
+            .repartitionByRange("chromosome", "position")
+            .sortWithinPartitions("chromosome", "position")
             .write.mode(session.write_mode)
             .parquet(variant_index_path)
         )


### PR DESCRIPTION
There are some issues with variant index partitioning:

- As mentioned by @jdhayhurst in opentargets/issues#3567, using the `partitionBy` strategy for writing the `variantIndex` implies that we need to infer the type of the `chromosome` column which can be problematic.

- The dataset is partitioned in too many small parts (4.9k objects for a total of 2.0 GiB)

- The positions are sorted alphanumerically which is also not ideal:

```
|115700605|
|115701247|
| 11958647|
|119621629|
| 11964316|
| 11966298|
| 11970804|
| 11970806|
|119712012|
|119743899|
|119759154|
|119759915|
| 11976200|
|119764157|
```


This PR reverts the `partitionBy` strategy and changes it to a partitionByRange + sortWithinPartitions

```
# repartition
In [29]: df.repartitionByRange("chromosome", "position").sortWithinPartitions("chromosome", "position").write.parquet(path="/Users
    ...: /ochoa/test")
    
In [31]: test = spark.read.parquet("/Users/ochoa/test")
    
In [35]: test.withColumn("partition", f.spark_partition_id()).groupBy(f.col("partition")).agg(f.count("position").alias("count"),f
    ...: .collect_set(f.col("chromosome")).alias("chromosomes"), f.min(f.col("position")).alias("min_position"),f.max(f.col("posit
    ...: ion")).alias("max_position")).sort("chromosomes","min_position").show(150)
    
+---------+-----+-----------+------------+------------+                         
|partition|count|chromosomes|min_position|max_position|
+---------+-----+-----------+------------+------------+
|       46|22662|        [1]|       54490|    41214381|
|       72|23663|        [1]|    41214727|    47155645|
|       27|32908|        [1]|    47155696|    99891325|
|       33|24968|        [1]|    99891326|   154586278|
|       30|31852|        [1]|   154586282|   212423225|
|       78|31106|        [1]|   212423867|   237830625|
|        6|40592|    [1, 10]|       62603|   248595228|
|       57|30777|       [10]|    35126627|    70690138|
|       28|31356|       [10]|    70690255|    89141699|
|       61|30000|       [10]|    89141843|   102627256|
|       90|22442|       [11]|     5234385|    47441750|
|       86|15803|       [11]|    47441752|    62822675|
|       73|15610|       [11]|    62822703|    68914919|
|       56|31246|       [11]|    68914920|   108299767|
|       70|24645|   [11, 10]|      175339|   133766637|
|       40|33070|       [12]|     5044398|    49027131|
|      104|15646|       [12]|    49027133|    52492828|
|       51|15651|       [12]|    52492830|    57578088|
|       64|23821|       [12]|    57578089|   123830649|
|       69|24579|   [12, 11]|       21162|   126027313|
|       23|46779|       [13]|    23719938|    42066205|
|        5|48684|       [13]|    42067171|    77198319|
|       48|40192|       [13]|    77198670|   113291190|
|       68|22913|   [13, 12]|    16407276|   133264319|
|      116| 8015|   [13, 14]|    18262425|   114353919|
|      101| 8583|       [14]|    21287999|    23390341|
|       67|22620|       [14]|    23390342|    35114861|
|       15|40153|       [14]|    35115003|    58141361|
|        0|38874|       [14]|    58141430|    73661980|
|       34|32375|       [14]|    73662015|    91339320|
|       29|30402|       [14]|    91339348|   102039618|
|      107|15837|       [14]|   102039622|   105152190|
|       75|24999|       [15]|    27790512|    40382371|
|       36|23565|       [15]|    40382719|    46249049|
|       16|39728|       [15]|    46249093|    61963835|
|       54|30643|       [15]|    61963837|    74228594|
|       65|22880|       [15]|    74228616|    82354711|
|       41|24467|       [15]|    82356065|    90749520|
|       50|15823|   [15, 14]|    19345401|   106882765|
|       84|23466|   [15, 16]|       53423|   101957704|
|      112| 7707|       [16]|      757953|     2080362|
|      108|15846|       [16]|     2080363|    23635619|
|      102|14545|       [16]|    23635620|    67700648|
|       43|23627|       [16]|    67700650|    77316160|
|       83|23026|       [16]|    77316494|    89771803|
|       91|15548|       [17]|    10651041|    31226427|
|      105|15896|       [17]|    31226429|    42169707|
|      114| 8019|       [17]|    42170234|    43063314|
|      117| 8219|       [17]|    43063315|    43094430|
|       89|16219|       [17]|    43094431|    48958680|
|       92|23158|       [17]|    48958681|    68527892|
|      103|16037|       [17]|    68527893|    82081305|
|       94|15281|   [17, 16]|      129496|    89956455|
|        7|40311|   [17, 18]|       46050|    82091414|
|       87|16558|       [19]|      336350|    11035083|
|       77|15156|       [19]|    11035086|    13228714|
|       85|15421|       [19]|    13228716|    22789195|
|      106|14580|       [19]|    22789444|    38512396|
|       95|15495|       [19]|    38512402|    45997101|
|      113| 7590|       [19]|    45997603|    49211678|
|      110| 8152|       [19]|    49211732|    50402192|
|      115| 8021|       [19]|    50402194|    52678095|
|       99| 7977|       [19]|    52678181|    54370173|
|       76|31199|   [19, 18]|      229480|    80262545|
|       17|37897|        [2]|    26055026|    44402968|
|       24|46099|        [2]|    44404173|    68163104|
|       59|26768|        [2]|    68163377|    96254993|
|        9|47677|        [2]|    96254997|   161362269|
|       26|46534|        [2]|   161364414|   178718395|
|       12|48503|        [2]|   178718398|   215709083|
|       74|23027|        [2]|   215709160|   229804066|
|       53|23272|    [2, 19]|       12696|    55623412|
|       47|24397|       [20]|    10554578|    49219010|
|       31|31783|    [20, 2]|       82603|   242165988|
|       39|22914|   [20, 21]|     5031194|    64331516|
|        8|39497|       [21]|    17958983|    43027101|
|       32|23354|   [21, 22]|    10537023|    46699514|
|       79|16038|       [22]|    17113437|    21620414|
|       52|17049|       [22]|    21621988|    28640312|
|       66|22408|       [22]|    28640477|    32586018|
|       44|23955|       [22]|    32586073|    41620858|
|       38|23833|       [22]|    41620951|    50625615|
|      100|17047|        [3]|    42686078|    49419245|
|       62|23339|        [3]|    49419250|    56621174|
|       21|45833|        [3]|    56621183|   121772608|
|       58|32882|        [3]|   121772614|   180661891|
|       25|40474|    [3, 22]|       13051|    50807787|
|       19|29778|     [3, 4]|       11913|   198167849|
|       18|39585|        [4]|     7589407|    89782842|
|        3|46168|        [5]|      117132|    78353079|
|        2|55746|        [5]|    78353208|   127246426|
|       63|31050|        [5]|   127246796|   139664632|
|       37|23918|        [5]|   139668650|   154282469|
|       10|46879|     [5, 4]|       13114|   189917972|
|       11|31574|     [5, 6]|      142840|   181207878|
|       93|15613|        [6]|     1679481|    33443433|
|       13|38808|        [6]|    33443440|    56592177|
|        4|55198|        [6]|    56592186|   147257697|
|       42|32037|        [7]|    21615288|    87409280|
|       22|30556|        [7]|    87409284|   101118992|
|       88|31645|        [7]|   101119358|   127909190|
|       80|23770|        [7]|   127911350|   140822262|
|       20|39534|     [7, 6]|       32858|   170080456|
|        1|40510|        [8]|     6107152|    55894815|
|       14|46117|        [8]|    55894940|   124772807|
|      109|15760|        [8]|   124774367|   143919237|
|       55|24231|     [8, 7]|      224055|   159253737|
|       97|15821|     [8, 9]|       11110|   145000747|
|       60|31204|        [9]|    15260821|    91166833|
|       49|31739|        [9]|    91167070|    99506436|
|       82|31348|        [9]|    99506579|   127665304|
|       71|22651|        [9]|   127665317|   132897213|
|      111|15151|        [9]|   132897214|   136202325|
|       81|16228| [MT, X, 9]|          73|   138217661|
|       96|31815|        [X]|      484011|    48323226|
|       35|31599|        [X]|    48323332|    76893145|
|       45|38796|        [X]|    76894153|   150081721|
|       98|16228|     [X, Y]|     2787015|   156025429|
+---------+-----+-----------+------------+------------+
```

This should resolve the BE issues and also provide noticeable speed improvements when performing joins on variant_index (e.g. L2G)