### PR TITLE
fix(l2g): remove custom session params + other fixes

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -222,6 +222,7 @@ class LDBasedClumpingConfig(StepConfig):
 class LocusToGeneConfig(StepConfig):
     """Locus to gene step configuration."""
 
+    session: Any = field(default_factory=lambda: {"extended_spark_conf": None})
     run_mode: str = MISSING
     predictions_path: str = MISSING
     credible_set_path: str = MISSING

--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -303,12 +303,18 @@ class LocusToGeneFeatureMatrixConfig(StepConfig):
             "eQtlColocClppMaximum",
             "pQtlColocClppMaximum",
             "sQtlColocClppMaximum",
-            "tuQtlColocClppMaximum",
             # max H4 for each (study, locus, gene) aggregating over a specific qtl type
             "eQtlColocH4Maximum",
             "pQtlColocH4Maximum",
             "sQtlColocH4Maximum",
-            "tuQtlColocH4Maximum",
+            # max CLPP for each (study, locus, gene) aggregating over a specific qtl type and in relation with the mean in the vicinity
+            "eQtlColocClppMaximumNeighbourhood",
+            "pQtlColocClppMaximumNeighbourhood",
+            "sQtlColocClppMaximumNeighbourhood",
+            # max H4 for each (study, locus, gene) aggregating over a specific qtl type and in relation with the mean in the vicinity
+            "eQtlColocH4MaximumNeighbourhood",
+            "pQtlColocH4MaximumNeighbourhood",
+            "sQtlColocH4MaximumNeighbourhood",
             # distance to gene footprint
             "distanceSentinelFootprint",
             "distanceSentinelFootprintNeighbourhood",

--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -222,16 +222,6 @@ class LDBasedClumpingConfig(StepConfig):
 class LocusToGeneConfig(StepConfig):
     """Locus to gene step configuration."""
 
-    session: Any = field(
-        default_factory=lambda: {
-            "extended_spark_conf": {
-                "spark.dynamicAllocation.enabled": "false",
-                "spark.driver.memory": "48g",
-                "spark.executor.memory": "48g",
-                "spark.sql.shuffle.partitions": "800",
-            }
-        }
-    )
     run_mode: str = MISSING
     predictions_path: str = MISSING
     credible_set_path: str = MISSING

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -10,7 +10,7 @@ from wandb import login as wandb_login
 
 from gentropy.common.session import Session
 from gentropy.common.utils import access_gcp_secret
-from gentropy.config import LocusToGeneConfig
+from gentropy.config import LocusToGeneConfig, LocusToGeneFeatureMatrixConfig
 from gentropy.dataset.colocalisation import Colocalisation
 from gentropy.dataset.gene_index import GeneIndex
 from gentropy.dataset.l2g_feature_matrix import L2GFeatureMatrix
@@ -31,7 +31,7 @@ class LocusToGeneFeatureMatrixStep:
         self,
         session: Session,
         *,
-        features_list: list[str] = LocusToGeneConfig().features_list,
+        features_list: list[str] = LocusToGeneFeatureMatrixConfig().features_list,
         credible_set_path: str,
         variant_index_path: str | None = None,
         colocalisation_path: str | None = None,


### PR DESCRIPTION
## ✨ Context
@d0choa observed a Java memory issue when running the L2G training
```
Caused by: [CIRCULAR REFERENCE: org.apache.spark.SparkException: Cannot broadcast the table that is larger than 8GB: 13 GB]
```
(more [here](https://console.cloud.google.com/dataproc/jobs/4941c761-4200-4ade-8555-f2353dcb1b7d/monitoring?region=europe-west1&authuser=1&project=open-targets-genetics-dev))

The L2G training step had a custom session that provided more memory to the cluster. This was inherited from the previous L2G version where this step included the feature matrix generation and the training was happening in Spark.
Because L2G is now a much lighter step, the default spark configuration should be enough.

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

- Removal of the session parameter in the `LocusToGeneStepConfig` that extended the spark configuration. I am still defining the default session inside the step configuration, because otherwise I'd need to provide it if I want to access any step attribuites. This is because the child step inherits from the Step class, which requires a session. For example:
```
# if LocusToGeneConfig doesn't include session

LocusToGeneConfig().features_list
>> TypeError: LocusToGeneConfig.__init__() missing 1 required positional argument: 'session'

# default session values for LocusToGeneConfig
@dataclass
class LocusToGeneConfig(StepConfig):
    """Locus to gene step configuration."""

    session: Any = field(default_factory=lambda: {"extended_spark_conf": None})

LocusToGeneConfig().features_list
>> ['eQtlColocClppMaximum',
 'pQtlColocClppMaximum',
 'sQtlColocClppMaximum',
 'eQtlColocH4Maximum',
...]
```
- Minor issues: addition of the colocalisation neighbourhood features to the feature matrix step

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

Didn't run the whole L2G step (run into an error that https://github.com/opentargets/gentropy/pull/837 fixes), but the crash wasn't due to Java.
## 🚦 Before submitting

- [ ] Do these changes cover one single feature (one change at a time)?
- [ ] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [ ] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ ] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
