### PR TITLE
feat(coloc): step refactoring

### DIFF
--- a/src/gentropy/colocalisation.py
+++ b/src/gentropy/colocalisation.py
@@ -61,14 +61,12 @@ class ColocalisationStep:
 
         # Transform
         overlaps = credible_set.find_overlaps()
-        overlaps.df.show()
 
         # Make a partial caller to ensure that colocalisation_method_params are added to the call only when dict is not empty
         coloc = colocalisation_class.colocalise
         if colocalisation_method_params:
             coloc = partial(coloc, **colocalisation_method_params)
         colocalisation_results = coloc(overlaps)
-        colocalisation_results.df.show()
         # Load
         colocalisation_results.df.write.mode(session.write_mode).parquet(
             f"{coloc_path}/{colocalisation_method.lower()}"

--- a/src/gentropy/colocalisation.py
+++ b/src/gentropy/colocalisation.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import inspect
-from importlib import import_module
+from typing import Any, Type
 
 from pyspark.sql.functions import col
 
 from gentropy.common.session import Session
 from gentropy.dataset.study_locus import StudyLocus
-from gentropy.method.colocalisation import Coloc
+from gentropy.method.colocalisation import Coloc, ColocalisationMethodInterface
 
 
 class ColocalisationStep:
@@ -18,43 +17,51 @@ class ColocalisationStep:
     This workflow runs colocalisation analyses that assess the degree to which independent signals of the association share the same causal variant in a region of the genome, typically limited by linkage disequilibrium (LD).
     """
 
+    __coloc_methods__ = {
+        method.METHOD_NAME.lower(): method
+        for method in ColocalisationMethodInterface.__subclasses__()
+    }
+
     def __init__(
         self,
         session: Session,
         credible_set_path: str,
         coloc_path: str,
         colocalisation_method: str,
-        priorc1: float = 1e-4,
-        priorc2: float = 1e-4,
-        priorc12: float = 1e-5,
+        colocalisation_method_params: dict[str, Any],
     ) -> None:
         """Run Colocalisation step.
+
+        This step allows for running two colocalisation methods: ecaviar and coloc.
 
         Args:
             session (Session): Session object.
             credible_set_path (str): Input credible sets path.
             coloc_path (str): Output Colocalisation path.
             colocalisation_method (str): Colocalisation method.
-            priorc1 (float): Prior on variant being causal for trait 1. Defaults to 1e-4.
-            priorc2 (float): Prior on variant being causal for trait 2. Defaults to 1e-4.
-            priorc12 (float): Prior on variant being causal for both traits. Defaults to 1e-5.
+            colocalisation_method_params (dict[str, Any]): Keyword arguments passed to the colocalise method of Colocalisation class.
+
+        Keyword Args:
+            priorc1 (float): Prior on variant being causal for trait 1. Defaults to 1e-4. For coloc method only.
+            priorc2 (float): Prior on variant being causal for trait 2. Defaults to 1e-4. For coloc method only.
+            priorc12 (float): Prior on variant being causal for both traits. Defaults to 1e-5. For coloc method only.
         """
+        colocalisation_method = colocalisation_method.lower()
         colocalisation_class = self._get_colocalisation_class(colocalisation_method)
+
         # Extract
-        credible_set = (
-            StudyLocus.from_parquet(
-                session, credible_set_path, recursiveFileLookup=True
-            ).filter(col("finemappingMethod").isin("SuSie", "SuSiE-inf"))
-            if colocalisation_class is Coloc
-            else StudyLocus.from_parquet(
-                session, credible_set_path, recursiveFileLookup=True
-            )
+        credible_set = StudyLocus.from_parquet(
+            session, credible_set_path, recusiveFileLookup=True
         )
+        if colocalisation_method == Coloc.METHOD_NAME.lower():
+            credible_set = credible_set.filter(
+                col("finemappingMethod").isin("SuSie", "SuSiE-inf")
+            )
 
         # Transform
         overlaps = credible_set.find_overlaps()
-        colocalisation_results = colocalisation_class.colocalise(  # type: ignore
-            overlaps, priorc1=priorc1, priorc2=priorc2, priorc12=priorc12
+        colocalisation_results = colocalisation_class.colocalise(
+            overlaps, **colocalisation_method_params
         )
 
         # Load
@@ -63,14 +70,16 @@ class ColocalisationStep:
         )
 
     @classmethod
-    def _get_colocalisation_class(cls: type[ColocalisationStep], method: str) -> type:
+    def _get_colocalisation_class(
+        cls, method: str
+    ) -> Type[ColocalisationMethodInterface]:
         """Get colocalisation class.
 
         Args:
             method (str): Colocalisation method.
 
         Returns:
-            type: Colocalisation class.
+            Type[ColocalisationMethodInterface]: Class that implements the ColocalisationMethodInterface.
 
         Raises:
             ValueError: if method not available.
@@ -79,15 +88,8 @@ class ColocalisationStep:
             >>> ColocalisationStep._get_colocalisation_class("ECaviar")
             <class 'gentropy.method.colocalisation.ECaviar'>
         """
-        module_name = "gentropy.method.colocalisation"
-        module = import_module(module_name)
-
-        available_methods = []
-        for class_name, class_obj in inspect.getmembers(module, inspect.isclass):
-            if class_obj.__module__ == module_name:
-                available_methods.append(class_name)
-                if class_name == method:
-                    return class_obj
-        raise ValueError(
-            f"Method {method} is not supported. Available: {(', ').join(available_methods)}"
-        )
+        method = method.lower()
+        if method not in cls.__coloc_methods__:
+            raise ValueError(f"Colocalisation method {method} not available.")
+        coloc_method = cls.__coloc_methods__[method]
+        return coloc_method

--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -38,9 +38,7 @@ class ColocalisationConfig(StepConfig):
     credible_set_path: str = MISSING
     coloc_path: str = MISSING
     colocalisation_method: str = MISSING
-    priorc1: float = MISSING
-    priorc2: float = MISSING
-    priorc12: float = MISSING
+    colocalisation_method_params: dict[str, Any] = field(default_factory=dict[str, Any])
     _target_: str = "gentropy.colocalisation.ColocalisationStep"
 
 

--- a/src/gentropy/dataset/colocalisation.py
+++ b/src/gentropy/dataset/colocalisation.py
@@ -83,7 +83,7 @@ class Colocalisation(Dataset):
 
         method_colocalisation_metric = ColocalisationStep._get_colocalisation_class(
             filter_by_colocalisation_method
-        ).METHOD_METRIC  # type: ignore
+        ).METHOD_METRIC
 
         coloc_filtering_expr = [
             f.col("rightGeneId").isNotNull(),

--- a/src/gentropy/method/colocalisation.py
+++ b/src/gentropy/method/colocalisation.py
@@ -30,13 +30,13 @@ class ColocalisationMethodInterface(Protocol):
 
     @classmethod
     def colocalise(
-        cls, overlapping_signals: StudyLocusOverlap, **kwargs: dict[str, Any]
+        cls, overlapping_signals: StudyLocusOverlap, **kwargs: Any
     ) -> Colocalisation:
         """Method to generate the colocalisation.
 
         Args:
             overlapping_signals (StudyLocusOverlap): Overlapping study loci.
-            **kwargs (dict[str,Any]): Additional keyword arguments to the colocalise method.
+            **kwargs (Any): Additional keyword arguments to the colocalise method.
 
 
         Returns:
@@ -90,13 +90,13 @@ class ECaviar(ColocalisationMethodInterface):
     def colocalise(
         cls: type[ECaviar],
         overlapping_signals: StudyLocusOverlap,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> Colocalisation:
         """Calculate bayesian colocalisation based on overlapping signals.
 
         Args:
             overlapping_signals (StudyLocusOverlap): overlapping signals.
-            **kwargs (dict[str, Any]): Additional parameters passed to the colocalise method.
+            **kwargs (Any): Additional parameters passed to the colocalise method.
 
         Returns:
             Colocalisation: colocalisation results based on eCAVIAR.
@@ -174,13 +174,13 @@ class Coloc(ColocalisationMethodInterface):
     def colocalise(
         cls: type[Coloc],
         overlapping_signals: StudyLocusOverlap,
-        **kwargs: dict[str, Any],
+        **kwargs: float,
     ) -> Colocalisation:
         """Calculate bayesian colocalisation based on overlapping signals.
 
         Args:
             overlapping_signals (StudyLocusOverlap): overlapping peaks
-            **kwargs (dict[str, Any]): Additional parameters passed to the colocalise method.
+            **kwargs (float): Additional parameters passed to the colocalise method.
 
         Keyword Args:
             priorc1 (float): Prior on variant being causal for trait 1. Defaults to 1e-4.

--- a/src/gentropy/method/colocalisation.py
+++ b/src/gentropy/method/colocalisation.py
@@ -14,6 +14,8 @@ from gentropy.common.utils import get_logsum
 from gentropy.dataset.colocalisation import Colocalisation
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from numpy.typing import NDArray
     from pyspark.sql import Column
 
@@ -60,12 +62,15 @@ class ECaviar:
 
     @classmethod
     def colocalise(
-        cls: type[ECaviar], overlapping_signals: StudyLocusOverlap
+        cls: type[ECaviar],
+        overlapping_signals: StudyLocusOverlap,
+        **kwargs: dict[str, Any],
     ) -> Colocalisation:
         """Calculate bayesian colocalisation based on overlapping signals.
 
         Args:
             overlapping_signals (StudyLocusOverlap): overlapping signals.
+            **kwargs (dict[str, Any]): Additional parameters to the coloc step.
 
         Returns:
             Colocalisation: colocalisation results based on eCAVIAR.

--- a/tests/gentropy/dataset/test_study_index.py
+++ b/tests/gentropy/dataset/test_study_index.py
@@ -444,7 +444,6 @@ class TestDiseaseValidation:
                 "backgroundTraitFromSourceMappedIds", f.array().cast("array<string>")
             )
         )
-        study_df.show()
         # Mock study index:
         self.study_index = StudyIndex(
             _df=study_df,

--- a/tests/gentropy/method/test_colocalisation_method.py
+++ b/tests/gentropy/method/test_colocalisation_method.py
@@ -17,6 +17,12 @@ from gentropy.method.colocalisation import Coloc, ECaviar
 def test_coloc(mock_study_locus_overlap: StudyLocusOverlap) -> None:
     """Test coloc."""
     assert isinstance(Coloc.colocalise(mock_study_locus_overlap), Colocalisation)
+    assert isinstance(
+        Coloc.colocalise(
+            mock_study_locus_overlap, priorc1=1e-4, priorc2=1e-4, priorc12=1e-5
+        ),
+        Colocalisation,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/gentropy/step/test_colocalisation_step.py
+++ b/tests/gentropy/step/test_colocalisation_step.py
@@ -1,0 +1,293 @@
+"""Test colocalisation step."""
+
+from pathlib import Path
+from typing import Type
+
+import pytest
+
+from gentropy.colocalisation import ColocalisationStep
+from gentropy.common.session import Session
+from gentropy.dataset.colocalisation import Colocalisation
+from gentropy.dataset.study_locus import StudyLocus
+from gentropy.method.colocalisation import Coloc, ColocalisationMethodInterface, ECaviar
+
+
+@pytest.mark.step_test
+class TestColocalisationStep:
+    """Test colocalisation steps."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, session: Session, tmp_path: Path) -> None:
+        """Setup StudyLocus for testing."""
+        credible_set_data = [
+            (
+                "-1299941111165481046",
+                "gwas",
+                "1_62634374_G_GA",
+                "1",
+                62634374,
+                "1:62116600-63176657",
+                "GCST90269661",
+                None,
+                -18.026562155233105,
+                8.294741,
+                -72,
+                None,
+                None,
+                None,
+                [
+                    "Variant not found in LD reference, Study locus finemapped without in-sample LD reference"
+                ],
+                "SuSiE-inf",
+                2,
+                128.08235878972883,
+                1.0,
+                1.0,
+                62116600,
+                63176657,
+                None,
+                [("1_62634374_G_GA", 1.0)],
+                [
+                    (
+                        True,
+                        True,
+                        303.2017476882394,
+                        1.0,
+                        "1_62634374_G_GA",
+                        None,
+                        None,
+                        -0.07779708137213309,
+                        None,
+                        None,
+                    )
+                ],
+                "SuSiE fine-mapped credible set with out-of-sample LD",
+            ),
+            (
+                "-1245591334543437941",
+                "gwas",
+                "1_62725906_C_A",
+                "1",
+                62725906,
+                "1:62275115-62861709",
+                "GCST90024601",
+                None,
+                6.818181818181818,
+                1.0845997,
+                -12,
+                None,
+                None,
+                None,
+                [
+                    "Variant not found in LD reference, Study locus finemapped without in-sample LD reference"
+                ],
+                "SuSiE-inf",
+                3,
+                903.4374513916813,
+                1.0,
+                1.0,
+                62275115,
+                62861709,
+                None,
+                [("1_62725906_C_A", 1.0)],
+                [
+                    (
+                        True,
+                        True,
+                        2087.4457573345685,
+                        0.9999999999381545,
+                        "1_62725906_C_A",
+                        None,
+                        None,
+                        0.20241232721094407,
+                        None,
+                        None,
+                    )
+                ],
+                "SuSiE fine-mapped credible set with out-of-sample LD",
+            ),
+            (
+                "-0.20241232721094407",
+                "gwas",
+                "1_62725906_C_A",
+                "1",
+                62725906,
+                "1:62335572-62883302",
+                "GCST90025461",
+                None,
+                6.363636363636364,
+                5.0753098,
+                -10,
+                None,
+                None,
+                None,
+                [
+                    "Variant not found in LD reference, Study locus finemapped without in-sample LD reference"
+                ],
+                "SuSiE-inf",
+                2,
+                912.1598183692258,
+                1.0,
+                1.0,
+                62335572,
+                62883302,
+                None,
+                [("1_62725906_C_A", 1.0)],
+                [
+                    (
+                        True,
+                        True,
+                        2107.38950418228,
+                        0.9999999999454303,
+                        "1_62725906_C_A",
+                        None,
+                        None,
+                        0.20330391077149534,
+                        None,
+                        None,
+                    )
+                ],
+                "SuSiE fine-mapped credible set with out-of-sample LD",
+            ),
+            (
+                "-2271857845883525223",
+                "gwas",
+                "1_62634374_G_GA",
+                "1",
+                62634374,
+                "1:62192511-63034021",
+                "GCST90269580",
+                None,
+                -15.43232373355239,
+                1.0077391,
+                -54,
+                None,
+                None,
+                None,
+                [
+                    "Variant not found in LD reference, Study locus finemapped without in-sample LD reference"
+                ],
+                "SuSiE-inf",
+                2,
+                104.77639852123883,
+                1.0,
+                1.0,
+                62192511,
+                63034021,
+                None,
+                [("1_62634374_G_GA", 1.0)],
+                [
+                    (
+                        True,
+                        True,
+                        249.20354469210795,
+                        1.0,
+                        "1_62634374_G_GA",
+                        None,
+                        None,
+                        -0.07071263272378725,
+                        None,
+                        None,
+                    )
+                ],
+                "SuSiE fine-mapped credible set with out-of-sample LD",
+            ),
+        ]
+        self.credible_set_path = str(tmp_path / "credible_set_datasets")
+        session.spark.createDataFrame(
+            credible_set_data, schema=StudyLocus.get_schema()
+        ).write.parquet(self.credible_set_path)
+        self.coloc_path = str(tmp_path / "colocalisation")
+
+    @pytest.mark.parametrize(
+        ["label", "expected_method"],
+        [
+            pytest.param("coloc", Coloc, id="coloc method"),
+            pytest.param("ecaviar", ECaviar, id="ecaviar method"),
+            pytest.param("ECaviar", ECaviar, id="uppercase label"),
+        ],
+    )
+    def test_get_colocalisation_class(
+        self, label: str, expected_method: Type[ColocalisationMethodInterface]
+    ) -> None:
+        """Test _get_colocalisation_class method on ColocalisationStep."""
+        method = ColocalisationStep._get_colocalisation_class(label)
+        assert (
+            method is expected_method
+        ), "Incorrect colocalisation class returned by ColocalisationStep._get_colocalisation_class(label)"
+
+    def test_label_with_invalid_method(self) -> None:
+        """Test what happens when invalid method_label is passed to the _get_colocalisation_class."""
+        with pytest.raises(ValueError):
+            ColocalisationStep._get_colocalisation_class("NewMethod")
+
+    @pytest.mark.parametrize(
+        ["coloc_method", "expected_data"],
+        [
+            pytest.param(
+                "ecaviar",
+                {
+                    "clpp": [1.0, 1.0],
+                    "colocalisationMethod": ["eCAVIAR", "eCAVIAR"],
+                    "leftStudyLocusId": [
+                        "-1245591334543437941",
+                        "-2271857845883525223",
+                    ],
+                    "rightStudyLocusId": [
+                        "-0.20241232721094407",
+                        "-1299941111165481046",
+                    ],
+                },
+                id="ecaviar",
+            ),
+            pytest.param(
+                "coloc",
+                {
+                    "h4": [1.0, 1.0],
+                    "h3": [0.0, 0.0],
+                    "h2": [0.0, 0.0],
+                    "h1": [0.0, 0.0],
+                    "h0": [0.0, 0.0],
+                    "colocalisationMethod": ["COLOC", "COLOC"],
+                    "leftStudyLocusId": [
+                        "-1245591334543437941",
+                        "-2271857845883525223",
+                    ],
+                    "rightStudyLocusId": [
+                        "-0.20241232721094407",
+                        "-1299941111165481046",
+                    ],
+                },
+                id="coloc",
+            ),
+        ],
+    )
+    def test_colocalise(
+        self,
+        coloc_method: str,
+        expected_data: dict[str, list[float] | list[str]],
+        session: Session,
+    ) -> None:
+        """Test colocalise method."""
+        ColocalisationStep(
+            session=session,
+            credible_set_path=self.credible_set_path,
+            coloc_path=self.coloc_path,
+            colocalisation_method=coloc_method,
+        )
+
+        coloc_dataset = Colocalisation.from_parquet(
+            session, self.coloc_path, recursiveFileLookup=True
+        )
+        for column in expected_data:
+            values = [c[column] for c in coloc_dataset.df.collect()]
+            expected_values = expected_data[column]
+            for v, e in zip(values, expected_values):
+                if isinstance(e, float):
+                    assert (
+                        e == pytest.approx(v, 1e-1)
+                    ), f"Incorrect value {v} at {column} found in {coloc_method}, expected {e}"
+                else:
+                    assert (
+                        e == v
+                    ), f"Incorrect value {v} at {column} found in {coloc_method}, expected {e}"

--- a/utils/install_dependencies.sh
+++ b/utils/install_dependencies.sh
@@ -1,12 +1,14 @@
+#!/usr/bin/env bash
+export SHELL_RC=$(echo "$HOME/.${SHELL##*/}rc")
 if ! command -v pyenv &>/dev/null; then
     echo "Installing Pyenv, a tool to manage multiple Python versions..."
     curl -sSL https://pyenv.run | bash
-    # Add Pyenv configuration to ~/.bashrc.
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-    echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+    # Add Pyenv configuration to rc.
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >>$SHELL_RC
+    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >>$SHELL_RC
+    echo 'eval "$(pyenv init -)"' >>$SHELL_RC
     # And also execute it right now.
-    . <(tail -n3 ~/.bashrc)
+    . <(tail -n3 $SHELL_RC)
 fi
 
 echo "Activating Pyenv environment with a Python version required for the project..."

--- a/utils/install_dependencies.sh
+++ b/utils/install_dependencies.sh
@@ -1,14 +1,12 @@
-#!/usr/bin/env bash
-export SHELL_RC=$(echo "$HOME/.${SHELL##*/}rc")
 if ! command -v pyenv &>/dev/null; then
     echo "Installing Pyenv, a tool to manage multiple Python versions..."
     curl -sSL https://pyenv.run | bash
-    # Add Pyenv configuration to rc.
-    echo 'export PYENV_ROOT="$HOME/.pyenv"' >>$SHELL_RC
-    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >>$SHELL_RC
-    echo 'eval "$(pyenv init -)"' >>$SHELL_RC
+    # Add Pyenv configuration to ~/.bashrc.
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+    echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+    echo 'eval "$(pyenv init -)"' >> ~/.bashrc
     # And also execute it right now.
-    . <(tail -n3 $SHELL_RC)
+    . <(tail -n3 ~/.bashrc)
 fi
 
 echo "Activating Pyenv environment with a Python version required for the project..."


### PR DESCRIPTION
## ✨ Context

The PR https://github.com/opentargets/gentropy/pull/830 added `prior` required arguments to the `ColocalisationStep`. As the step uses the `colocalisation_method` to evaluate which coloc method to use (Coloc or ECaviar), passing the required `prior` arguments to the `ColocaliseMethod.coloc()` will result in a bug within the `ECaviar` method, that does not require these parameters.


<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

This PR attempts to fix the issue by 
- [x] introducing a list of keyword arguments that can be passed to the `ColocalisationStep` under the `colocalisation_method_params`
- [x] Addition of ColocalisationStep tests to ensure the integrity of the step test with data extracted from 
    - coloc_path = "gs://ot_orchestration/releases/24.10_freeze2/colocalisation"
    - cs_path = "gs://ot_orchestration/releases/24.10_freeze2/credible_set"
- [x] Introduction of `ColocalisationMethodInterface` class that implements the interface for any colocalisation method that should satisfy the `ColocalistationStep`
- [x] Refactoring of Coloc, ECaviar and ColocalisationStep classes


The default behavior of the Coloc method is to use the provided `colocalisation_method_parameters` if passed, else it fallbacks to the default values:
- `priorc1` = 1e-4
- `priorc2` = 1e-4
- `priorc12` = 1e-5

Example how to run the `ColocalisationStep` with overloading the parameters
```python
ColocalisationStep(session, credible_set_path, coloc_path, colocalisation_method="coloc", colocalisation_method_params={"priorc1:e-4, "priorc2":1e-4, "priorc12": 1e-5})
```
To run the step from the CLI
```bash
gentropy \
      step=colocalisation \
      step.credible_set_path=gs://ot_orchestration/releases/24.10/credible_set \
      step.coloc_path=gs://ot_orchestration/releases/24.10/colocalisation \
      step.colocalisation_method=Coloc \
      +step.colocalisation_method_params='{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}'


step:
  session:
    start_hail: false
    write_mode: errorifexists
    spark_uri: local[*]
    hail_home: /Users/ss60/Public/projects/gentropy/.venv/lib/python3.10/site-packages/hail
    extended_spark_conf: {}
    _target_: gentropy.common.session.Session
  credible_set_path: gs://ot_orchestration/releases/24.10/credible_set
  coloc_path: gs://ot_orchestration/releases/24.10/colocalisation
  colocalisation_method: Coloc
  colocalisation_method_params:
    priorc1: 0.0001
    priorc2: 0.0001
    priorc12: 1.0e-05
  _target_: gentropy.colocalisation.ColocalisationStep
datasets: {}
```

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
