### PR TITLE
test: skip `fetch_coordinates_from_rsids`

### DIFF
--- a/src/gentropy/datasource/ensembl/api.py
+++ b/src/gentropy/datasource/ensembl/api.py
@@ -20,7 +20,7 @@ def fetch_coordinates_from_rsids(
         Exception: If an error occurs while processing the batches.
 
     Example:
-        >>> fetch_coordinates_from_rsids(["rs75493593"])
+        >>> fetch_coordinates_from_rsids(["rs75493593"])  # doctest: +SKIP
         {'rs75493593': ['17_7041768_G_C', '17_7041768_G_T']}
     """
 


### PR DESCRIPTION
## ✨ Context
Ensembl's API call fails sometimes, making the test crash. This PR doesn't remove the test, just tells pytest to skip it.
````
----> 1 fetch_coordinates_from_rsids(["rs75493593"])

File ~/MEGAsync/EBI/repos/gentropy/src/gentropy/datasource/ensembl/api.py:91, in fetch_coordinates_from_rsids(rsids, batch_size, pause_time)
     88         all_results.update(_parse_response(variant_data))
     90     except Exception as e:
---> 91         raise Exception(f"Error processing batch {i // batch_size + 1}: {e}") from e
     93     time.sleep(pause_time)
     95 return all_results

Exception: Error processing batch 1: HTTP Error 500: Internal Server Error
```
