### PR TITLE
feat: flagging duplicated entries while keeping one of the duplicates

### DIFF
--- a/src/gentropy/dataset/dataset.py
+++ b/src/gentropy/dataset/dataset.py
@@ -322,7 +322,9 @@ class Dataset(ABC):
 
     @staticmethod
     def flag_duplicates(test_column: Column) -> Column:
-        """Return True for duplicated values in column.
+        """Return True for rows, where the value was already seen in column.
+
+        This implementation allows keeping the first occurrence of the value.
 
         Args:
             test_column (Column): Column to check for duplicates
@@ -331,12 +333,7 @@ class Dataset(ABC):
             Column: Column with a boolean flag for duplicates
         """
         return (
-            f.count(test_column).over(
-                Window.partitionBy(test_column).rowsBetween(
-                    Window.unboundedPreceding, Window.unboundedFollowing
-                )
-            )
-            > 1
+            f.row_number().over(Window.partitionBy(test_column).orderBy(f.rand())) > 1
         )
 
     @staticmethod

--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -49,6 +49,8 @@ class StudyLocusValidationStep:
             .filter_credible_set(credible_interval=CredibleInterval.IS99)
             # Annotate credible set confidence:
             .assign_confidence()
+            # Flagging credible sets that are duplicated:
+            .validate_unique_study_locus_id()
         ).persist()  # we will need this for 2 types of outputs
 
         study_locus_with_qc.valid_rows(invalid_qc_reasons, invalid=True).df.write.mode(

--- a/tests/gentropy/dataset/test_study_index.py
+++ b/tests/gentropy/dataset/test_study_index.py
@@ -313,7 +313,7 @@ class TestUniquenessValidation:
     STUDY_DATA = [
         # This is the only study to be flagged:
         ("s1", "eqtl", "p"),
-        ("s1", "eqtl", "p"),
+        ("s1", "eqtl", "p"),  # Duplicate -> one should be flagged
         ("s3", "gwas", "p"),
         ("s4", "gwas", "p"),
     ]
@@ -338,7 +338,7 @@ class TestUniquenessValidation:
         validated = self.study_index.validate_unique_study_id().persist()
 
         # We have more than one flagged studies:
-        assert validated.df.filter(f.size(f.col("qualityControls")) > 0).count() > 1
+        assert validated.df.filter(f.size(f.col("qualityControls")) > 0).count() == 1
 
         # The flagged study identifiers are found more than once:
         flagged_ids = {

--- a/tests/gentropy/dataset/test_study_index.py
+++ b/tests/gentropy/dataset/test_study_index.py
@@ -337,7 +337,7 @@ class TestUniquenessValidation:
         """Testing if the function returns the right type."""
         validated = self.study_index.validate_unique_study_id().persist()
 
-        # We have more than one flagged studies:
+        # We have only one flagged study:
         assert validated.df.filter(f.size(f.col("qualityControls")) > 0).count() == 1
 
         # The flagged study identifiers are found more than once:
@@ -350,7 +350,7 @@ class TestUniquenessValidation:
         }
 
         for _, count in flagged_ids.items():
-            assert count > 1
+            assert count == 1
 
         # the right study is found:
         assert "s1" in flagged_ids


### PR DESCRIPTION
## ✨ Context

The duplication flagging is updated to keep one of the duplicates unflagged. + test.

There's no need to change configuration, as the ETL config already list the flag for [passing qc.](https://github.com/opentargets/orchestration/blob/60724899ca1b9b440c505ff19508f44de2b85bc1/src/ot_orchestration/dags/config/genetics_etl.yaml#L65-L66)