### PR TITLE
fix: ensure the #CHROM is not quoted

### DIFF
--- a/tests/gentropy/step/test_convert_to_vcf_step.py
+++ b/tests/gentropy/step/test_convert_to_vcf_step.py
@@ -115,7 +115,6 @@ class TestConvertToVcfStep:
         )
         output_path = str(tmp_path / "variants")
         ConvertToVcfStep(session, [source_path], ["json"], output_path, 10)
-
         partitions = [
             str(p) for p in Path(output_path).iterdir() if str(p).endswith("csv")
         ]
@@ -125,24 +124,28 @@ class TestConvertToVcfStep:
             usecols=[0, 1],  # just read #CHROM and POS
             sep="\t",
         )
-        assert df.equals(
-            # values comes from input file tests/gentropy/data_samples/variant_sources/uniprot-test-sorting.jsonl
-            # NOTE: Natural ordering in CHROM (str) and POS (int)
-            pd.DataFrame(
-                [
-                    ("1", 1525242),
-                    ("1", 161306863),
-                    ("11", 108345818),
-                    ("2", 98396018),
-                    ("21", 44286656),
-                    ("3", 38585800),
-                    ("MT", 6277),
-                    ("X", 129562612),
-                    ("Y", 2787426),
-                ],
-                columns=["#CHROM", "POS"],
-            )
-        ), "Variant sorting does not match expectations."
+        # values comes from input file tests/gentropy/data_samples/variant_sources/uniprot-test-sorting.jsonl
+        # NOTE: Natural ordering in CHROM (str) and POS (int)
+        with open(partitions[0]) as fp:
+            assert fp.readline().startswith("CHROM\tPOS")
+
+        expected_df = pd.DataFrame(
+            [
+                ("1", 1525242),
+                ("1", 161306863),
+                ("11", 108345818),
+                ("2", 98396018),
+                ("21", 44286656),
+                ("3", 38585800),
+                ("MT", 6277),
+                ("X", 129562612),
+                ("Y", 2787426),
+            ],
+            columns=["CHROM", "POS"],
+        )
+
+        assert list(df.columns) == list(expected_df.columns)
+        assert df.equals(expected_df), "Variant sorting does not match expectations."
 
     def test_raises_assertion_imbalanced_arg_ratios(self, session: Session) -> None:
         """Test imbalanced argument ratio exception.


### PR DESCRIPTION
## ✨ Context

The output from `convertToVcf` step uses the `csv writer` which can not write the `#CHROM` column correctly to the output csv file, as writer quotes the column, so the result is `"#CRHOM"`. This PR resolves this in a temporary solution, by removing the hash, that will be readded before the vep command is executed in the orchestration.

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [ ] Do these changes cover one single feature (one change at a time)?
- [ ] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [ ] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ ] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
