### PR TITLE
feat: adding l2g features to prediction table

### DIFF
--- a/src/gentropy/assets/schemas/l2g_predictions.json
+++ b/src/gentropy/assets/schemas/l2g_predictions.json
@@ -18,6 +18,17 @@
       "type": "double",
       "nullable": false,
       "metadata": {}
+    },
+    {
+      "metadata": {},
+      "name": "locusToGeneFeatures",
+      "nullable": true,
+      "type": {
+        "keyType": "string",
+        "type": "map",
+        "valueContainsNull": true,
+        "valueType": "float"
+      }
     }
   ]
 }

--- a/src/gentropy/dataset/l2g_features/other.py
+++ b/src/gentropy/dataset/l2g_features/other.py
@@ -291,10 +291,10 @@ class CredibleSetConfidenceFeature(L2GFeature):
                             ),
                         ),
                         on="variantId",
-                        how="left",
+                        how="inner",
                     )
                     # Annotate credible set confidence
-                    .join(full_credible_set, ["variantId", "studyId"], "left")
+                    .join(full_credible_set, ["variantId", "studyId"])
                     .select("studyLocusId", "geneId", cls.feature_name)
                 ),
                 id_vars=("studyLocusId", "geneId"),

--- a/src/gentropy/dataset/l2g_prediction.py
+++ b/src/gentropy/dataset/l2g_prediction.py
@@ -127,7 +127,7 @@ class L2GPrediction(Dataset):
             )
         )
 
-    def add_features(
+    def add_locus_to_gene_features(
         self: L2GPrediction, feature_matrix: L2GFeatureMatrix
     ) -> L2GPrediction:
         """Add features to the L2G predictions.

--- a/src/gentropy/dataset/l2g_prediction.py
+++ b/src/gentropy/dataset/l2g_prediction.py
@@ -138,6 +138,10 @@ class L2GPrediction(Dataset):
         Returns:
             L2GPrediction: L2G predictions with additional features
         """
+        # Testing if `locusToGeneFeatures` column already exists:
+        if "locusToGeneFeatures" in self.df.columns:
+            self.df = self.df.drop("locusToGeneFeatures")
+
         # Columns identifying a studyLocus/gene pair
         prediction_id_columns = ["studyLocusId", "geneId"]
 

--- a/src/gentropy/dataset/l2g_prediction.py
+++ b/src/gentropy/dataset/l2g_prediction.py
@@ -149,22 +149,15 @@ class L2GPrediction(Dataset):
         ]
 
         # Aggregating all features into a single map column:
-        aggregated_features = (
-            feature_matrix._df.withColumn(
-                "locusToGeneFeatures",
-                f.create_map(
-                    *sum(
-                        [
-                            (f.lit(colname), f.col(colname))
-                            for colname in columns_to_map
-                        ],
-                        (),
-                    )
-                ),
-            )
-            .drop(*columns_to_map)
-            .show(1, False, True)
-        )
+        aggregated_features = feature_matrix._df.withColumn(
+            "locusToGeneFeatures",
+            f.create_map(
+                *sum(
+                    [(f.lit(colname), f.col(colname)) for colname in columns_to_map],
+                    (),
+                )
+            ),
+        ).drop(*columns_to_map)
         return L2GPrediction(
             _df=self.df.join(aggregated_features, on=prediction_id_columns, how="left"),
             _schema=self.get_schema(),

--- a/src/gentropy/dataset/l2g_prediction.py
+++ b/src/gentropy/dataset/l2g_prediction.py
@@ -153,15 +153,26 @@ class L2GPrediction(Dataset):
         ]
 
         # Aggregating all features into a single map column:
-        aggregated_features = feature_matrix._df.withColumn(
-            "locusToGeneFeatures",
-            f.create_map(
-                *sum(
-                    [(f.lit(colname), f.col(colname)) for colname in columns_to_map],
-                    (),
-                )
-            ),
-        ).drop(*columns_to_map)
+        aggregated_features = (
+            feature_matrix._df.withColumn(
+                "locusToGeneFeatures",
+                f.create_map(
+                    *sum(
+                        [
+                            (f.lit(colname), f.col(colname))
+                            for colname in columns_to_map
+                        ],
+                        (),
+                    )
+                ),
+            )
+            # from the freshly created map, we filter out the null values
+            .withColumn(
+                "locusToGeneFeatures",
+                f.expr("map_filter(locusToGeneFeatures, (k, v) -> v is not null)"),
+            )
+            .drop(*columns_to_map)
+        )
         return L2GPrediction(
             _df=self.df.join(aggregated_features, on=prediction_id_columns, how="left"),
             _schema=self.get_schema(),

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -190,7 +190,7 @@ class LocusToGeneStep:
             hf_token=access_gcp_secret("hfhub-key", "open-targets-genetics-dev"),
             download_from_hub=self.download_from_hub,
         )
-        predictions.add_features(self.feature_matrix).df.write.mode(
+        predictions.add_locus_to_gene_features(self.feature_matrix).df.write.mode(
             self.session.write_mode
         ).parquet(self.predictions_path)
         self.session.logger.info("L2G predictions saved successfully.")


### PR DESCRIPTION
A simple extension of the l2g step to add feature matrix to l2g prediction table. As such the following updates were made:

- Schema of l2g prediction is updated to have an extra optional column to contain features as a map.
- l2g prediction dataset is extended with a method to enrich dataset with the provided features.
- l2g step is extended with calling the above method.