### PR TITLE
feat: improve partitioning of credible sets

### DIFF
--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -58,8 +58,8 @@ class StudyLocusValidationStep:
         # Valid study locus partitioned to simplify the finding of overlaps
         study_locus_with_qc.valid_rows(
             invalid_qc_reasons, invalid=True
-        ).df.repartitionByRange("chromosome", "studyLocusId").sortWithinPartitions(
-            "chromosome", "studyLocusId"
+        ).df.repartitionByRange("chromosome", "position").sortWithinPartitions(
+            "chromosome", "position"
         ).write.mode(session.write_mode).parquet(invalid_study_locus_path)
 
         # Infalid study locus

--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -55,10 +55,14 @@ class StudyLocusValidationStep:
             .assign_confidence()
         ).persist()  # we will need this for 2 types of outputs
 
-        study_locus_with_qc.valid_rows(invalid_qc_reasons, invalid=True).df.write.mode(
-            session.write_mode
-        ).parquet(invalid_study_locus_path)
+        # Valid study locus partitioned to simplify the finding of overlaps
+        study_locus_with_qc.valid_rows(
+            invalid_qc_reasons, invalid=True
+        ).df.repartitionByRange("chromosome", "studyLocusId").sortWithinPartitions(
+            "chromosome", "studyLocusId"
+        ).write.mode(session.write_mode).parquet(invalid_study_locus_path)
 
+        # Infalid study locus
         study_locus_with_qc.valid_rows(invalid_qc_reasons).df.write.mode(
             session.write_mode
         ).parquet(valid_study_locus_path)


### PR DESCRIPTION
The current credible sets after validation are completely shuffled. This can have a performance cost in all downstream processes.

```
In [7]: cs.select("chromosome", "position").show()
+----------+---------+
|chromosome| position|
+----------+---------+
|         2|151525381|
|         1|162388605|
|        10|102449815|
|         2| 47169327|
|        21| 42298501|
|         8| 85157259|
|         1| 11838976|
|        20| 45919050|
|         2|106566631|
|        16| 14889311|
|         1| 17005181|
|         2| 99176335|
|         1|149185498|
|         X|  1661217|
|         X|   312722|
|        11|   807149|
|        10| 79836221|
|         2| 73063040|
|        14| 55647604|
|         5| 43001499|
+----------+---------+
only showing top 20 rows
```

To improve the partitioning, this PR implements partitioning by range using `chromosome` and `position`.

The benefits on performance still need to be evaluated