### PR TITLE
feat(variant index): variant description to summarise variant consequences in transcripts

### DIFF
--- a/src/gentropy/assets/schemas/variant_index.json
+++ b/src/gentropy/assets/schemas/variant_index.json
@@ -194,6 +194,18 @@
             },
             {
               "metadata": {},
+              "name": "approvedSymbol",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "biotype",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
               "name": "transcriptId",
               "nullable": true,
               "type": "string"
@@ -271,6 +283,12 @@
         },
         "type": "array"
       }
+    },
+    {
+      "metadata": {},
+      "name": "variantDescription",
+      "nullable": false,
+      "type": "string"
     }
   ],
   "type": "struct"

--- a/src/gentropy/assets/schemas/vep_json_output.json
+++ b/src/gentropy/assets/schemas/vep_json_output.json
@@ -342,6 +342,18 @@
             },
             {
               "metadata": {},
+              "name": "gene_symbol",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "biotype",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
               "name": "appris",
               "nullable": true,
               "type": "string"

--- a/src/gentropy/datasource/ensembl/vep_parser.py
+++ b/src/gentropy/datasource/ensembl/vep_parser.py
@@ -95,7 +95,6 @@ class VariantEffectPredictorParser:
             _schema=VariantIndex.get_schema(),
             id_threshold=hash_threshold,
         )
-        # return VariantEffectPredictorParser.process_vep_output(vep_data, hash_threshold)
 
     @staticmethod
     def _extract_ensembl_xrefs(colocated_variants: Column) -> Column:


### PR DESCRIPTION
## ✨ Context

For an easier interpretation of variants, certain key fields from the variant annotation table are combined together to create a `variantDescription`. This is stored and will be shown on the UI.

**Fields to combine:**

- `biotype` - Shown if not protein coding, description always shows the variant impact on the closest protein coding transcript
- `most severe consequence` - always shows the label.
- `approvedSymbol` or `geneId` - always shown for the listed listed transcripts.
- `distanceFromFootprint` - shown if transcripts are not overlapping with the variant
- `aminoAcidChange` - shown if variant causes amino acid change.
- `lofteePrediction` - shown if the variant is high-confidence loss of function predicted by loftee

