### PR TITLE
feat: gzip evicence output to match existing format

### DIFF
--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -309,7 +309,7 @@ class LocusToGeneEvidenceStep:
             locus_to_gene_predictions_path (str): Path to the L2G predictions dataset
             credible_set_path (str): Path to the credible set dataset
             study_index_path (str): Path to the study index dataset
-            evidence_output_path (str): Path to the L2G evidence output dataset
+            evidence_output_path (str): Path to the L2G evidence output dataset. The output format is ndjson gzipped.
             locus_to_gene_threshold (float, optional): Threshold to consider a gene as a target. Defaults to 0.05.
         """
         # Reading the predictions

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -328,6 +328,7 @@ class LocusToGeneEvidenceStep:
                 credible_sets, study_index, locus_to_gene_threshold
             )
             .write.mode(session.write_mode)
+            .option("compression", "gzip")
             .json(evidence_output_path)
         )
 


### PR DESCRIPTION
## ✨ Context

The evidence datasets are all in packed ndjson format.

```
☁  orchestration [783f989] ⚡  gsutil ls gs://open-targets-ppp-releases/24.09dev/input/evidence-files
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/atlas.json.bz2
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/cancerbiomarkers.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/chembl.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/clingen.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/cosmic.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/crispr.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/crispr_screen.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/encore.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/eva.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/gene2phenotype.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/gene_burden.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/genetics-portal-evidences.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/genomics_england.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/impc.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/intogen.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/orphanet.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/ot_crispr.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/progeny.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/reactome.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/slapenrich.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/sysbio.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/uniprot.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/validation_lab.json.gz
gs://open-targets-ppp-releases/24.09dev/input/evidence-files/epmc/
```

To follow this pattern and make it consistent I have added the `compress` option in the evidence writer.

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

- [x] Adds `gzip` compression to ETL evidence output.

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
