### PR TITLE
chore(gnomad): updating GnomAD version to 4.1 from 4.0 + using joint frequencies

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -387,7 +387,7 @@ class GnomadVariantConfig(StepConfig):
         }
     )
     variant_annotation_path: str = MISSING
-    gnomad_genomes_path: str = "gs://gcp-public-data--gnomad/release/4.0/ht/genomes/gnomad.genomes.v4.0.sites.ht/"
+    gnomad_genomes_path: str = "gs://gcp-public-data--gnomad/release/4.1/ht/genomes/gnomad.genomes.v4.1.sites.ht/"
     gnomad_variant_populations: list[str] = field(
         default_factory=lambda: [
             "afr",  # African-American

--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -387,7 +387,9 @@ class GnomadVariantConfig(StepConfig):
         }
     )
     variant_annotation_path: str = MISSING
-    gnomad_genomes_path: str = "gs://gcp-public-data--gnomad/release/4.1/ht/genomes/gnomad.genomes.v4.1.sites.ht/"
+    gnomad_genomes_path: str = (
+        "gs://gcp-public-data--gnomad/release/4.1/ht/joint/gnomad.joint.v4.1.sites.ht/"
+    )
     gnomad_variant_populations: list[str] = field(
         default_factory=lambda: [
             "afr",  # African-American

--- a/src/gentropy/datasource/gnomad/variants.py
+++ b/src/gentropy/datasource/gnomad/variants.py
@@ -84,7 +84,9 @@ class GnomADVariants:
                     ).map(
                         lambda p: hl.struct(
                             populationName=p,
-                            alleleFrequency=ht.freq[ht.globals.freq_index_dict[p]].AF,
+                            alleleFrequency=ht.joint.freq[
+                                ht.joint_globals.freq_index_dict[p]
+                            ].AF,
                         )
                     ),
                     # Extract in silico predictors:

--- a/src/gentropy/datasource/gnomad/variants.py
+++ b/src/gentropy/datasource/gnomad/variants.py
@@ -89,29 +89,29 @@ class GnomADVariants:
                             ].AF,
                         )
                     ),
-                    # Extract in silico predictors:
-                    inSilicoPredictors=hl.array(
-                        [
-                            hl.struct(
-                                method=hl.str("SpliceAI"),
-                                assessment=hl.missing(hl.tstr),
-                                score=hl.expr.functions.float32(
-                                    ht.in_silico_predictors.spliceai_ds_max
-                                ),
-                                assessmentFlag=hl.missing(hl.tstr),
-                                targetId=hl.missing(hl.tstr),
-                            ),
-                            hl.struct(
-                                method=hl.str("Pangolin"),
-                                assessment=hl.missing(hl.tstr),
-                                score=hl.expr.functions.float32(
-                                    ht.in_silico_predictors.pangolin_largest_ds
-                                ),
-                                assessmentFlag=hl.missing(hl.tstr),
-                                targetId=hl.missing(hl.tstr),
-                            ),
-                        ]
-                    ),
+                    # # Extract in silico predictors:
+                    # inSilicoPredictors=hl.array(
+                    #     [
+                    #         hl.struct(
+                    #             method=hl.str("SpliceAI"),
+                    #             assessment=hl.missing(hl.tstr),
+                    #             score=hl.expr.functions.float32(
+                    #                 ht.in_silico_predictors.spliceai_ds_max
+                    #             ),
+                    #             assessmentFlag=hl.missing(hl.tstr),
+                    #             targetId=hl.missing(hl.tstr),
+                    #         ),
+                    #         hl.struct(
+                    #             method=hl.str("Pangolin"),
+                    #             assessment=hl.missing(hl.tstr),
+                    #             score=hl.expr.functions.float32(
+                    #                 ht.in_silico_predictors.pangolin_largest_ds
+                    #             ),
+                    #             assessmentFlag=hl.missing(hl.tstr),
+                    #             targetId=hl.missing(hl.tstr),
+                    #         ),
+                    #     ]
+                    # ),
                     # Extract cross references to GnomAD:
                     dbXrefs=hl.array(
                         [

--- a/src/gentropy/gnomad_ingestion.py
+++ b/src/gentropy/gnomad_ingestion.py
@@ -105,6 +105,8 @@ class GnomadVariantIndexStep:
                 gnomad_genomes_path, variant_annotation_path
             )
 
+        session.logger.info("Gnomad variant annotation path:")
+        session.logger.info(variant_annotation_path)
         # Parse variant info from source.
         (
             GnomADVariants(


### PR DESCRIPTION
## ✨ Context

- [x] Default configuration for GnomAD variant annotation is updated to 4.1 from 4.0.
- [x] The configuration + parsing logic is updated to point to the joint variant data instead of the full genome data.
- [x] Removing in-silico prediction extraction from GnomAD data for various reason: questionable licecing, predictors are not available in the joint dataset.

The new dataset is saved here: `gs://gnomad_data_2/v4.1/variant_index`, confirmed that the allele frequencies are concordant with the GnomAD UI joint frequencies.