### PR TITLE
feat: allow building package from tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 PROJECT_ID ?= open-targets-genetics-dev
 REGION ?= europe-west1
 APP_NAME ?= $$(cat pyproject.toml | grep -m 1 "name" | cut -d" " -f3 | sed  's/"//g')
-REF ?= $$(git rev-parse --abbrev-ref HEAD)
 PACKAGE_VERSION ?= $$(poetry version --short)
+# NOTE: git rev-parse will always return the HEAD if it sits in the tag,
+# this way we can distinguish the tag vs branch name
+ifeq ($(shell git rev-parse --abbrev-ref HEAD)),HEAD)
+		REF := $(shell git rev-parse --abbrev-ref HEAD)
+else
+		REF := $(shell git describe --exact-match --tags)
+endif
+
 CLEAN_PACKAGE_VERSION := $(shell echo "$(PACKAGE_VERSION)" | tr -cd '[:alnum:]')
 BUCKET_NAME=gs://genetics_etl_python_playground/initialisation/${APP_NAME}/${REF}
 

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ PACKAGE_VERSION ?= $$(poetry version --short)
 # NOTE: git rev-parse will always return the HEAD if it sits in the tag,
 # this way we can distinguish the tag vs branch name
 ifeq ($(shell git rev-parse --abbrev-ref HEAD)),HEAD)
-		REF := $(shell git rev-parse --abbrev-ref HEAD)
+	REF := $(shell git rev-parse --abbrev-ref HEAD)
 else
-		REF := $(shell git describe --exact-match --tags)
+	REF := $(shell git describe --exact-match --tags)
 endif
 
 CLEAN_PACKAGE_VERSION := $(shell echo "$(PACKAGE_VERSION)" | tr -cd '[:alnum:]')


### PR DESCRIPTION
## ✨ Context

`git rev-parse --abbrev-ref HEAD` command returns `HEAD` when the repository sits in the tag
This PR fixes the issue with `make build` that does not capture the tag and builds the artifacts under incorrect namespace.

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests? tested on local tag
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
