### PR TITLE
feat: coalescing the datasets

### DIFF
--- a/src/gentropy/biosample_index.py
+++ b/src/gentropy/biosample_index.py
@@ -1,4 +1,5 @@
 """Step to generate biosample index dataset."""
+
 from __future__ import annotations
 
 from gentropy.common.session import Session
@@ -28,10 +29,16 @@ class BiosampleIndexStep:
             efo_input_path (str): Input efo dataset path.
             biosample_index_path (str): Output gene index dataset path.
         """
-        cell_ontology_index = extract_ontology_from_json(cell_ontology_input_path, session.spark)
+        cell_ontology_index = extract_ontology_from_json(
+            cell_ontology_input_path, session.spark
+        )
         uberon_index = extract_ontology_from_json(uberon_input_path, session.spark)
-        efo_index = extract_ontology_from_json(efo_input_path, session.spark).retain_rows_with_ancestor_id(["CL_0000000"])
+        efo_index = extract_ontology_from_json(
+            efo_input_path, session.spark
+        ).retain_rows_with_ancestor_id(["CL_0000000"])
 
         biosample_index = cell_ontology_index.merge_indices([uberon_index, efo_index])
 
-        biosample_index.df.write.mode(session.write_mode).parquet(biosample_index_path)
+        biosample_index.df.coalesce(session.output_partitions).write.mode(
+            session.write_mode
+        ).parquet(biosample_index_path)

--- a/src/gentropy/colocalisation.py
+++ b/src/gentropy/colocalisation.py
@@ -70,9 +70,9 @@ class ColocalisationStep:
             coloc = partial(coloc, **colocalisation_method_params)
         colocalisation_results = coloc(overlaps)
         # Load
-        colocalisation_results.df.write.mode(session.write_mode).parquet(
-            f"{coloc_path}/{colocalisation_method.lower()}"
-        )
+        colocalisation_results.df.coalesce(session.output_partitions).write.mode(
+            session.write_mode
+        ).parquet(f"{coloc_path}/{colocalisation_method.lower()}")
 
     @classmethod
     def _get_colocalisation_class(

--- a/src/gentropy/common/session.py
+++ b/src/gentropy/common/session.py
@@ -24,6 +24,7 @@ class Session:
         hail_home: str | None = None,
         start_hail: bool = False,
         extended_spark_conf: dict[str, str] | None = None,
+        output_partitions: int = 200,
     ) -> None:
         """Initialises spark session and logger.
 
@@ -34,6 +35,7 @@ class Session:
             hail_home (str | None): Path to Hail installation. Defaults to None.
             start_hail (bool): Whether to start Hail. Defaults to False.
             extended_spark_conf (dict[str, str] | None): Extended Spark configuration. Defaults to None.
+            output_partitions (int): Number of partitions for output datasets. Defaults to 200.
         """
         merged_conf = self._create_merged_config(
             start_hail, hail_home, extended_spark_conf
@@ -53,6 +55,7 @@ class Session:
         self.start_hail = start_hail
         if start_hail:
             hl.init(sc=self.spark.sparkContext, log="/dev/null")
+        self.output_partitions = output_partitions
 
     def _default_config(self: Session) -> SparkConf:
         """Default spark configuration.

--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -18,6 +18,7 @@ class SessionConfig:
     spark_uri: str = "local[*]"
     hail_home: str = os.path.dirname(hail_location)
     extended_spark_conf: dict[str, str] | None = field(default_factory=dict[str, str])
+    output_partitions: int = 200
     _target_: str = "gentropy.common.session.Session"
 
 

--- a/src/gentropy/gene_index.py
+++ b/src/gentropy/gene_index.py
@@ -1,4 +1,5 @@
 """Step to generate gene index dataset."""
+
 from __future__ import annotations
 
 from gentropy.common.session import Session
@@ -28,4 +29,6 @@ class GeneIndexStep:
         # Transform
         gene_index = OpenTargetsTarget.as_gene_index(platform_target)
         # Load
-        gene_index.df.write.mode(session.write_mode).parquet(gene_index_path)
+        gene_index.df.coalesce(session.output_partitions).write.mode(
+            session.write_mode
+        ).parquet(gene_index_path)

--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -58,12 +58,12 @@ class StudyLocusValidationStep:
 
         # Valid study locus partitioned to simplify the finding of overlaps
         study_locus_with_qc.valid_rows(invalid_qc_reasons).df.repartitionByRange(
-            "chromosome", "position"
+            session.output_partitions, "chromosome", "position"
         ).sortWithinPartitions("chromosome", "position").write.mode(
             session.write_mode
         ).parquet(valid_study_locus_path)
 
         # Invalid study locus
-        study_locus_with_qc.valid_rows(invalid_qc_reasons, invalid=True).df.write.mode(
-            session.write_mode
-        ).parquet(invalid_study_locus_path)
+        study_locus_with_qc.valid_rows(invalid_qc_reasons, invalid=True).df.coalesce(
+            session.output_partitions
+        ).write.mode(session.write_mode).parquet(invalid_study_locus_path)

--- a/src/gentropy/study_validation.py
+++ b/src/gentropy/study_validation.py
@@ -71,10 +71,10 @@ class StudyValidationStep:
             )  # Flagging QTL studies with invalid biosamples
         ).persist()  # we will need this for 2 types of outputs
 
-        study_index_with_qc.valid_rows(invalid_qc_reasons, invalid=True).df.write.mode(
-            session.write_mode
-        ).parquet(invalid_study_index_path)
+        study_index_with_qc.valid_rows(invalid_qc_reasons, invalid=True).df.coalesce(
+            session.output_partitions
+        ).write.mode(session.write_mode).parquet(invalid_study_index_path)
 
-        study_index_with_qc.valid_rows(invalid_qc_reasons).df.write.mode(
-            session.write_mode
-        ).parquet(valid_study_index_path)
+        study_index_with_qc.valid_rows(invalid_qc_reasons).df.coalesce(
+            session.output_partitions
+        ).write.mode(session.write_mode).parquet(valid_study_index_path)

--- a/src/gentropy/variant_index.py
+++ b/src/gentropy/variant_index.py
@@ -56,7 +56,9 @@ class VariantIndexStep:
             variant_index = variant_index.add_annotation(annotations)
 
         (
-            variant_index.df.repartitionByRange("chromosome", "position")
+            variant_index.df.repartitionByRange(
+                session.output_partitions, "chromosome", "position"
+            )
             .sortWithinPartitions("chromosome", "position")
             .write.mode(session.write_mode)
             .parquet(variant_index_path)


### PR DESCRIPTION
## ✨ Context

As discussed with @javfg the outputs generated by gentropy ETL steps needs to coalesced to minimal number of partitions, so the POS can ingest them without performance issues.


The freeze10 dataset contains following data sizes:
```
7.67 MiB     gs://ot_orchestration/releases/24.11_freeze10/biosample_index/
2.35 GiB     gs://ot_orchestration/releases/24.11_freeze10/colocalisation/coloc/
3.37 GiB     gs://ot_orchestration/releases/24.11_freeze10/colocalisation/ecaviar/
5.72 GiB     gs://ot_orchestration/releases/24.11_freeze10/colocalisation/
2.12 GiB     gs://ot_orchestration/releases/24.11_freeze10/credible_set/
3.03 MiB     gs://ot_orchestration/releases/24.11_freeze10/gene_index/
1.89 GiB     gs://ot_orchestration/releases/24.11_freeze10/invalid_credible_set/
4.01 MiB     gs://ot_orchestration/releases/24.11_freeze10/invalid_study_index/
5.24 MiB     gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_associations/direct_associations/
8.31 MiB     gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_associations/indirect_associations/
13.54 MiB    gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_associations/
20.32 MiB    gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_evidence/
594.14 MiB   gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_feature_matrix/
90.65 MiB    gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_predictions/
85.56 MiB    gs://ot_orchestration/releases/24.11_freeze10/study_index/
2.41 GiB     gs://ot_orchestration/releases/24.11_freeze10/variant_index/
74.16 GiB    gs://ot_orchestration/releases/24.11_freeze10/variants/annotated_variants/
159.52 MiB   gs://ot_orchestration/releases/24.11_freeze10/variants/partitioned_variants/
74.31 GiB    gs://ot_orchestration/releases/24.11_freeze10/variants/
```

The above distribution means that the output number of partitions could vary and depend also on the partitioning method implemented in the step directly.


<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

 - To allow setting number of output partitions outside of the step I have added the new paramter to the gentropy session and used it in the key write operations along the steps. 
- The default value for the number of partitions should match the default used by `spark.sql.shuffle.partitions`. 

> [!NOTE]
> To use the `output_partitions` parameter one need to specify it in the `session.output_partitions = X`

> [!WARNING]
> The property `session.output_partitions` needs to be directly used when writing, so the overall shuffle partitions count along the process remains as set explicitly in `spark.sql.shuffle.partition` or 200.


<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
