### PR TITLE
fix: swap the ref parse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ APP_NAME ?= $$(cat pyproject.toml | grep -m 1 "name" | cut -d" " -f3 | sed  's/"
 PACKAGE_VERSION ?= $$(poetry version --short)
 # NOTE: git rev-parse will always return the HEAD if it sits in the tag,
 # this way we can distinguish the tag vs branch name
-ifeq ($(shell git rev-parse --abbrev-ref HEAD)),HEAD)
-	REF := $(shell git rev-parse --abbrev-ref HEAD)
-else
+ifeq ($(shell git rev-parse --abbrev-ref HEAD),HEAD)
 	REF := $(shell git describe --exact-match --tags)
+else
+	REF := $(shell git rev-parse --abbrev-ref HEAD)
 endif
 
 CLEAN_PACKAGE_VERSION := $(shell echo "$(PACKAGE_VERSION)" | tr -cd '[:alnum:]')


### PR DESCRIPTION
## ✨ Context

As @DSuveges found, there was an issue with how `make build` works. The condition to get the REF was swapped in Makefile, this PR attempts to fix it.

Tested on this branch and tag `test` and this branch build the artifacts with correct namespaces

```
 gentropy [szsz-fix-make-build] make build
Updated property [core/project].
Packaging Code and Dependencies for gentropy-0.0.0
Building gentropy (0.0.0)
  - Building sdist
  - Built gentropy-0.0.0.tar.gz
  - Building wheel
  - Built gentropy-0.0.0-py3-none-any.whl
Uploading to gs://genetics_etl_python_playground/initialisation/gentropy/szsz-fix-make-build
Copying file://src/gentropy/cli.py [Content-Type=text/x-python]...
/ [1 files][  546.0 B/  546.0 B]
Operation completed over 1 objects/546.0 B.
Copying file://./dist/gentropy-0.0.0-py3-none-any.whl [Content-Type=application/octet-stream]...
/ [1 files][264.4 KiB/264.4 KiB]
Operation completed over 1 objects/264.4 KiB.
Copying file://./utils/install_dependencies_on_cluster.sh [Content-Type=application/x-sh]...
/ [1 files][  1.8 KiB/  1.8 KiB]
Operation completed over 1 objects/1.8 KiB.
☁  gentropy [szsz-fix-make-build] git checkout test
Note: switching to 'test'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at e92fb336 fix: swap the ref parse
☁  gentropy [test] make build
Updated property [core/project].
Packaging Code and Dependencies for gentropy-0.0.0
Building gentropy (0.0.0)
  - Building sdist
  - Built gentropy-0.0.0.tar.gz
  - Building wheel
  - Built gentropy-0.0.0-py3-none-any.whl
Uploading to gs://genetics_etl_python_playground/initialisation/gentropy/test
Copying file://src/gentropy/cli.py [Content-Type=text/x-python]...
/ [1 files][  546.0 B/  546.0 B]
Operation completed over 1 objects/546.0 B.
Copying file://./dist/gentropy-0.0.0-py3-none-any.whl [Content-Type=application/octet-stream]...
/ [1 files][264.4 KiB/264.4 KiB]
Operation completed over 1 objects/264.4 KiB.
Copying file://./utils/install_dependencies_on_cluster.sh [Content-Type=application/x-sh]...
/ [1 files][  1.8 KiB/  1.8 KiB]
Operation completed over 1 objects/1.8 KiB.
```

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [ ] Do these changes cover one single feature (one change at a time)?
- [ ] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [ ] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ ] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `poetry run pre-commit run --all-files`)?
