### PR TITLE
fix: foldX normalisation to cover full range

### DIFF
--- a/src/gentropy/dataset/variant_index.py
+++ b/src/gentropy/dataset/variant_index.py
@@ -471,7 +471,7 @@ class InSilicoPredictorNormaliser:
         Returns:
             Column: Normalised energies
         """
-        return f.when(f.abs(score) >= 5, f.lit(1.0)).otherwise(
+        return f.when(f.abs(score) >= 2, f.lit(1.0)).otherwise(
             cls._rescaleColumnValue(f.abs(score), 0.0, 2.0, 0.0, 1.00)
         )
 


### PR DESCRIPTION
## ✨ Context

With the latest PR (#947) a bug got introduced into Fold-X energy normalisation. This fix ensures the full free energy range is covered.