### PR TITLE
fix(dataset): `filter` maintains instance attributes

### DIFF
--- a/src/gentropy/dataset/dataset.py
+++ b/src/gentropy/dataset/dataset.py
@@ -180,9 +180,9 @@ class Dataset(ABC):
         Returns:
             Self: Filtered Dataset
         """
-        df = self._df.filter(condition)
-        class_constructor = self.__class__
-        return class_constructor(_df=df, _schema=class_constructor.get_schema())
+        filtered_df = self._df.filter(condition)
+        attrs = {k: v for k, v in self.__dict__.items() if k != "_df"}
+        return self.__class__(_df=filtered_df, **attrs)
 
     def validate_schema(self: Dataset) -> None:
         """Validate DataFrame schema against expected class schema.


### PR DESCRIPTION
## ✨ Context
`Dataset.filter` returns a new instance where the data is filtered based on a given condition.
The new instance didn't keep all attributes the instance may have.

This has been pointed out by @xyg123, who run into an issue when running the L2G predictions step because the model wasn't bound to the predictions instance.

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

- Fix in `Dataset.filter`

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `uv run pre-commit run --all-files`)?
