### PR TITLE
fix(l2g): direct model path to hf repo when none and align training data filename

### DIFF
--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import pyspark.sql.functions as f
 from sklearn.ensemble import GradientBoostingClassifier
-from wandb.sdk.wandb_login import login as wandb_login
 
 from gentropy.common.schemas import compare_struct_schemas
 from gentropy.common.session import Session
@@ -24,6 +23,7 @@ from gentropy.dataset.variant_index import VariantIndex
 from gentropy.method.l2g.feature_factory import L2GFeatureInputLoader
 from gentropy.method.l2g.model import LocusToGeneModel
 from gentropy.method.l2g.trainer import LocusToGeneTrainer
+from wandb.sdk.wandb_login import login as wandb_login
 
 
 class LocusToGeneFeatureMatrixStep:
@@ -337,9 +337,7 @@ class LocusToGeneStep:
                     # we upload the model saved in the filesystem
                     self.model_path.split("/")[-1],
                     hf_hub_token,
-                    data=trained_model.training_data._df.drop(
-                        "goldStandardSet", "geneId"
-                    ).toPandas(),
+                    data=trained_model.training_data._df.toPandas(),
                     repo_id=self.hf_hub_repo_id,
                     commit_message=self.hf_model_commit_message,
                 )

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -151,7 +151,6 @@ class LocusToGeneStep:
 
         self.session = session
         self.run_mode = run_mode
-        self.model_path = model_path
         self.predictions_path = predictions_path
         self.features_list = list(features_list) if features_list else None
         self.hyperparameters = dict(hyperparameters)
@@ -164,6 +163,11 @@ class LocusToGeneStep:
         self.gold_standard_curation_path = gold_standard_curation_path
         self.gene_interactions_path = gene_interactions_path
         self.variant_index_path = variant_index_path
+        self.model_path = (
+            hf_hub_repo_id
+            if not model_path and download_from_hub and hf_hub_repo_id
+            else model_path
+        )
 
         # Load common inputs
         self.credible_set = StudyLocus.from_parquet(

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pyspark.sql.functions as f
 from sklearn.ensemble import GradientBoostingClassifier
+from wandb.sdk.wandb_login import login as wandb_login
 
 from gentropy.common.schemas import compare_struct_schemas
 from gentropy.common.session import Session
@@ -23,7 +24,6 @@ from gentropy.dataset.variant_index import VariantIndex
 from gentropy.method.l2g.feature_factory import L2GFeatureInputLoader
 from gentropy.method.l2g.model import LocusToGeneModel
 from gentropy.method.l2g.trainer import LocusToGeneTrainer
-from wandb.sdk.wandb_login import login as wandb_login
 
 
 class LocusToGeneFeatureMatrixStep:

--- a/src/gentropy/method/l2g/model.py
+++ b/src/gentropy/method/l2g/model.py
@@ -325,7 +325,7 @@ class LocusToGeneModel:
                 data=data,
             )
             self._create_hugging_face_model_card(local_repo)
-            data.to_parquet(f"{local_repo}/training_set.parquet")
+            data.to_parquet(f"{local_repo}/training_data.parquet")
             hub_utils.push(
                 repo_id=repo_id,
                 source=local_repo,


### PR DESCRIPTION
## ✨ Context
This PR fixes 2 minor bugs that was causing the L2G prediction step to crash when `model_path=None`:
- `L2GPrediction.from_credible_set` defaults to the `opentargets/locus_to_gene` repo if model_path is none. Now, at the L2G step level this variable matches `hf_repo_id` as long as `download_from_hub` is set to true
- Small typo in the filename of the training set when exporting to HF

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `uv run pre-commit run --all-files`)?
