### PR TITLE
chore(shap): sample background dataset to make explanation faster

### DIFF
--- a/src/gentropy/dataset/l2g_prediction.py
+++ b/src/gentropy/dataset/l2g_prediction.py
@@ -246,9 +246,11 @@ class L2GPrediction(Dataset):
             raise AttributeError(
                 "`model.training_data` is missing, seed dataset to get shapley values cannot be created."
             )
-        background_data = model.training_data._df.select(
-            *model.features_list
-        ).toPandas()
+        background_data = (
+            model.training_data._df.select(*model.features_list)
+            .toPandas()
+            .sample(n=1_000)
+        )
         explainer = shap.TreeExplainer(
             model.model,
             data=background_data,


### PR DESCRIPTION
## ✨ Context
L2G prediction step is exceedingly long. We estimate that it runs in ~5h, despite last week we generated predictions with explanations in 30 min.
We believe this is because of 2 main changes:
- L2G model is more than twice as big
- L2G training set that we passed as background dataset is more than twice as big

This slows down the SHAP values estimation.

<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

This PR applies sampling over the training set so that we only pass 1,000 records to the explainer. Based on the latest model and latest training set, we get a **base value of 0.06 with this**, very similar to the previous one. 
This was tested here https://github.com/opentargets/issues/issues/3755#issuecomment-2639518734

## 🙈 Missing

To investigate model size.

## 🚦 Before submitting

- [ ] Do these changes cover one single feature (one change at a time)?
- [ ] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [ ] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ ] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `uv run pre-commit run --all-files`)?
