### PR TITLE
fix: change posterior filter

### DIFF
--- a/src/gentropy/method/colocalisation.py
+++ b/src/gentropy/method/colocalisation.py
@@ -216,7 +216,7 @@ class Coloc(ColocalisationMethodInterface):
     METHOD_METRIC: str = "h4"
     PSEUDOCOUNT: float = 1e-10
     OVERLAP_SIZE_CUTOFF: int = 5
-    POSTERIOR_CUTOFF: float = 0.5
+    POSTERIOR_CUTOFF: float = 0.1
 
     @staticmethod
     def _get_posteriors(all_bfs: NDArray[np.float64]) -> DenseVector:

--- a/tests/gentropy/method/test_colocalisation_method.py
+++ b/tests/gentropy/method/test_colocalisation_method.py
@@ -249,7 +249,7 @@ def test_coloc(mock_study_locus_overlap: StudyLocusOverlap) -> None:
                         "right_logBF": 10.5,
                         "left_beta": 0.5,
                         "right_beta": 0.2,
-                        "left_posteriorProbability": 0.36,
+                        "left_posteriorProbability": 0.09,
                         "right_posteriorProbability": 0.92,
                     },
                 },


### PR DESCRIPTION

## 🛠 What does this PR implement

Change posterior threshold to 0.1 based on logBF ratio analysis (link).
## 🙈 Missing

In the future, this parameter should be exposed to the orchestration config.

## 🚦 Before submitting

- [ x] Do these changes cover one single feature (one change at a time)?
- [ x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ x] Did you make sure to update the documentation with your changes?
- [ x] Did you make sure there is no commented out code in this PR?
- [ x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ x] Did you make sure the branch is up-to-date with the `dev` branch?
- [ x] Did you write any new necessary tests?
- [ x] Did you make sure the changes pass local tests (`make test`)?
- [ x] Did you make sure the changes pass pre-commit rules (e.g `uv run pre-commit run --all-files`)?
