### PR TITLE
feat: adding metadata from dataset schemas

### DIFF
--- a/src/gentropy/assets/schemas/variant_index.json
+++ b/src/gentropy/assets/schemas/variant_index.json
@@ -1,37 +1,49 @@
 {
   "fields": [
     {
-      "metadata": {},
+      "metadata": {
+        "description": "The unique identifier for the variant following schema: {chromosome}-{position}-{referenceAllele}-{alternateAllele}"
+      },
       "name": "variantId",
       "nullable": false,
       "type": "string"
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "The chromosome on which the variant is located"
+      },
       "name": "chromosome",
       "nullable": false,
       "type": "string"
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "The position on the chromosome of the variant"
+      },
       "name": "position",
       "nullable": false,
       "type": "integer"
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "The reference allele for the variant"
+      },
       "name": "referenceAllele",
       "nullable": false,
       "type": "string"
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "The alternate allele for the variant"
+      },
       "name": "alternateAllele",
       "nullable": false,
       "type": "string"
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "List predicted or measured effect of the variant based on various methods"
+      },
       "name": "variantEffect",
       "nullable": true,
       "type": {
@@ -39,37 +51,49 @@
         "elementType": {
           "fields": [
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The method name used to predict the effect of the variant"
+              },
               "name": "method",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Textual assessment of the variant effect"
+              },
               "name": "assessment",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The score of the variant effect"
+              },
               "name": "score",
               "nullable": true,
               "type": "float"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Flagging if the variant effect is considered pathogenic"
+              },
               "name": "assessmentFlag",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The target identifier on which the variant effect is interpreted"
+              },
               "name": "targetId",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Variant effect normalised between -1 and 1"
+              },
               "name": "normalisedScore",
               "nullable": true,
               "type": "double"
@@ -81,7 +105,9 @@
       }
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "The sequence ontology identifier of the most severe consequence of the variant based on VEP"
+      },
       "name": "mostSevereConsequenceId",
       "nullable": true,
       "type": "string"
@@ -95,7 +121,9 @@
         "elementType": {
           "fields": [
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The sequence ontology identifier of the consequence of the variant based on VEP in the context of the transcript"
+              },
               "name": "variantFunctionalConsequenceIds",
               "nullable": true,
               "type": {
@@ -105,13 +133,17 @@
               }
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The amino acide change caused by this variant on this gene"
+              },
               "name": "aminoAcidChange",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "List of Uniprot identifiers of the gene product"
+              },
               "name": "uniprotAccessions",
               "nullable": true,
               "type": {
@@ -121,97 +153,129 @@
               }
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Flagging if the transcript is the canonical transcript for the gene"
+              },
               "name": "isEnsemblCanonical",
               "nullable": false,
               "type": "boolean"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The affected codon in the transcript"
+              },
               "name": "codons",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The distance of the variant from the transcript"
+              },
               "name": "distanceFromFootprint",
               "nullable": true,
               "type": "long"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The distance of the variant from the transcription start site"
+              },
               "name": "distanceFromTss",
               "nullable": true,
               "type": "long"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The appris annotation of the transcript"
+              },
               "name": "appris",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "MANE annotation of the transcript"
+              },
               "name": "maneSelect",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Ensembl gene identifier"
+              },
               "name": "targetId",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "VEP predicted impact of the variant on the transcript"
+              },
               "name": "impact",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Loss of function prediction based on LOFTEE"
+              },
               "name": "lofteePrediction",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "SIFT prediction of the variant impact on the transcript"
+              },
               "name": "siftPrediction",
               "nullable": true,
               "type": "float"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Polyphen prediction of the variant impact on the transcript"
+              },
               "name": "polyphenPrediction",
               "nullable": true,
               "type": "float"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Score based on VEP consequence"
+              },
               "name": "consequenceScore",
               "nullable": true,
               "type": "float"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The index of the transcript in the list of transcripts around the gene"
+              },
               "name": "transcriptIndex",
               "nullable": true,
               "type": "integer"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The HGNC gene symbol of the gene"
+              },
               "name": "approvedSymbol",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Biotype of the transcript"
+              },
               "name": "biotype",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "The Ensembl transcript identifier"
+              },
               "name": "transcriptId",
               "nullable": true,
               "type": "string"
@@ -223,7 +287,9 @@
       }
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "The list of rsIds for the variant"
+      },
       "name": "rsIds",
       "nullable": true,
       "type": {
@@ -233,7 +299,9 @@
       }
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "HGVS identifier of the variant"
+      },
       "name": "hgvsId",
       "nullable": true,
       "type": "string"
@@ -249,23 +317,31 @@
               "name": "populationName",
               "type": "string",
               "nullable": true,
-              "metadata": {}
+              "metadata": {
+                "description": "Name of the population"
+              }
             },
             {
               "name": "alleleFrequency",
               "type": "double",
               "nullable": true,
-              "metadata": {}
+              "metadata": {
+                "description": "The frequency of the alternate allele in the population"
+              }
             }
           ]
         },
         "containsNull": true
       },
       "nullable": true,
-      "metadata": {}
+      "metadata": {
+        "description": "The allele frequencies of the variant in different populations"
+      }
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "The list of cross-references for the variant in different databases"
+      },
       "name": "dbXrefs",
       "nullable": true,
       "type": {
@@ -273,13 +349,17 @@
         "elementType": {
           "fields": [
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Identifier of the variant in the given database"
+              },
               "name": "id",
               "nullable": true,
               "type": "string"
             },
             {
-              "metadata": {},
+              "metadata": {
+                "description": "Name of the database"
+              },
               "name": "source",
               "nullable": true,
               "type": "string"
@@ -291,7 +371,9 @@
       }
     },
     {
-      "metadata": {},
+      "metadata": {
+        "description": "Short summary of the variant effect"
+      },
       "name": "variantDescription",
       "nullable": true,
       "type": "string"

--- a/src/gentropy/assets/schemas/variant_index.json
+++ b/src/gentropy/assets/schemas/variant_index.json
@@ -2,7 +2,8 @@
   "fields": [
     {
       "metadata": {
-        "description": "The unique identifier for the variant following schema: {chromosome}-{position}-{referenceAllele}-{alternateAllele}"
+        "description": "The unique identifier for the variant following schema: {chromosome}-{position}-{referenceAllele}-{alternateAllele}",
+        "isPrimaryKey": true
       },
       "name": "variantId",
       "nullable": false,

--- a/src/gentropy/common/schemas.py
+++ b/src/gentropy/common/schemas.py
@@ -166,11 +166,11 @@ def compare_struct_schemas(
         schema_issues["missing_mandatory_columns"] += missing_required_fields
 
     # Converting schema to dictionaries for easier comparison:
-    observed_schema_dict = {field.name: field for field in observed_schema}
     expected_schema_dict = {field.name: field for field in expected_schema}
 
     # Testing optional fields and types:
-    for field_name, field in observed_schema_dict.items():
+    for field in observed_schema:
+        field_name = field.name
         # Testing observed field name, if name is not matched, no further tests are needed:
         if field_name not in expected_schema_dict:
             schema_issues["unexpected_columns"].append(
@@ -208,5 +208,11 @@ def compare_struct_schemas(
                 f"{parent_field_name}{field_name}[]",
                 schema_issues,
             )
+
+        # Extract metadata:
+        expected_metadata = expected_schema_dict[field_name].metadata
+
+        # Update observed metadata with expected metadata:
+        field.metadata = expected_metadata
 
     return schema_issues

--- a/src/gentropy/dataset/dataset.py
+++ b/src/gentropy/dataset/dataset.py
@@ -8,7 +8,7 @@ from enum import Enum
 from functools import reduce
 from typing import TYPE_CHECKING, Any
 
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as f
 from pyspark.sql import types as t
 from pyspark.sql.window import Window
@@ -200,6 +200,11 @@ class Dataset(ABC):
             raise SchemaValidationError(
                 f"Schema validation failed for {type(self).__name__}", discrepancies
             )
+
+        # if the schema validation is successful, we enforce the schema:
+        self._df = SparkSession.getActiveSession().createDataFrame(
+            self._df.rdd, observed_schema
+        )
 
     def valid_rows(self: Self, invalid_flags: list[str], invalid: bool = False) -> Self:
         """Filters `Dataset` according to a list of quality control flags. Only `Dataset` classes with a QC column can be validated.

--- a/src/gentropy/dataset/dataset.py
+++ b/src/gentropy/dataset/dataset.py
@@ -186,8 +186,11 @@ class Dataset(ABC):
         attrs = {k: v for k, v in self.__dict__.items() if k != "_df"}
         return self.__class__(_df=filtered_df, **attrs)
 
-    def validate_schema(self: Dataset) -> None:
+    def validate_schema(self: Dataset, propagate_metadata: bool = True) -> None:
         """Validate DataFrame schema against expected class schema.
+
+        Args:
+            propagate_metadata (bool): If True, propagates metadata from the expected schema to the DataFrame schema
 
         Raises:
             SchemaValidationError: If the DataFrame schema does not match the expected schema
@@ -202,9 +205,10 @@ class Dataset(ABC):
             )
 
         # if the schema validation is successful, we enforce the schema:
-        self._df = SparkSession.getActiveSession().createDataFrame(
-            self._df.rdd, observed_schema
-        )
+        if propagate_metadata:
+            self._df = SparkSession.getActiveSession().createDataFrame(
+                self._df.rdd, observed_schema
+            )
 
     def valid_rows(self: Self, invalid_flags: list[str], invalid: bool = False) -> Self:
         """Filters `Dataset` according to a list of quality control flags. Only `Dataset` classes with a QC column can be validated.


### PR DESCRIPTION
## ✨ Context

Column level metadata can be defined/added based on the dataset schema JSON files. This information then can be baked into the exported data, so any time the dataset is opened, the column level metadata information is available. This can also be directly used for generating data documentation via ml croissant.


## Contents

1. Variant index dataset annotated with column level metadata.
2. Schemas package is updated to extract metadata from the expected schema and added to observed schema.
3. Dataset.validate method optionally propagates the metadata to the dataset.

After the dataset is saved, the metadata is in the parquet files.