### PR TITLE
chore(l2g): make shap optional

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -284,6 +284,7 @@ class LocusToGeneConfig(StepConfig):
     hf_model_commit_message: str | None = "chore: update model"
     download_from_hub: bool = True
     cross_validate: bool = True
+    explain_predictions: bool = False
     _target_: str = "gentropy.l2g.LocusToGeneStep"
 
 

--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -284,7 +284,7 @@ class LocusToGeneConfig(StepConfig):
     hf_model_commit_message: str | None = "chore: update model"
     download_from_hub: bool = True
     cross_validate: bool = True
-    explain_predictions: bool = False
+    explain_predictions: bool | None = False
     _target_: str = "gentropy.l2g.LocusToGeneStep"
 
 

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -111,7 +111,7 @@ class LocusToGeneStep:
         credible_set_path: str,
         feature_matrix_path: str,
         model_path: str | None = None,
-        features_list: list[str] | None,
+        features_list: list[str] | None = None,
         gold_standard_curation_path: str | None = None,
         variant_index_path: str | None = None,
         gene_interactions_path: str | None = None,
@@ -119,6 +119,7 @@ class LocusToGeneStep:
         l2g_threshold: float | None = None,
         hf_hub_repo_id: str | None = None,
         hf_model_commit_message: str | None = "chore: update model",
+        explain_predictions: bool | None = None,
     ) -> None:
         """Initialise the step and run the logic based on mode.
 
@@ -140,6 +141,7 @@ class LocusToGeneStep:
             l2g_threshold (float | None): An optional threshold for the L2G score to filter predictions. A threshold of 0.05 is recommended.
             hf_hub_repo_id (str | None): Hugging Face Hub repository ID. If provided, the model will be uploaded to Hugging Face.
             hf_model_commit_message (str | None): Commit message when we upload the model to the Hugging Face Hub
+            explain_predictions (bool | None): Whether to extract SHAP importances for the L2G predictions. This is computationally expensive.
 
         Raises:
             ValueError: If run_mode is not 'train' or 'predict'
@@ -168,6 +170,7 @@ class LocusToGeneStep:
             if not model_path and download_from_hub and hf_hub_repo_id
             else model_path
         )
+        self.explain_predictions = explain_predictions
 
         # Load common inputs
         self.credible_set = StudyLocus.from_parquet(
@@ -292,9 +295,11 @@ class LocusToGeneStep:
             hf_token=access_gcp_secret("hfhub-key", "open-targets-genetics-dev"),
             download_from_hub=self.download_from_hub,
         )
+        if self.explain_predictions:
+            predictions = predictions.explain()
         predictions.filter(f.col("score") >= self.l2g_threshold).add_features(
             self.feature_matrix,
-        ).explain().df.coalesce(self.session.output_partitions).write.mode(
+        ).df.coalesce(self.session.output_partitions).write.mode(
             self.session.write_mode
         ).parquet(self.predictions_path)
         self.session.logger.info("L2G predictions saved successfully.")


### PR DESCRIPTION
## ✨ Context
In order to evaluate the latest model, I want to run the predictions step without extracting SHAPs.

I've tested this works in this [job](https://console.cloud.google.com/dataproc/jobs/e0f30568-52b5-4c09-b285-a087b14855e5/monitoring?region=europe-west1&authuser=1&inv=1&invt=AbrDlg&project=open-targets-genetics-dev).
<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement
- Adds `explain_predictions` (set to False by default) as a parameter to the L2G step

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `uv run pre-commit run --all-files`)?
