### PR TITLE
feat(l2g): update params after fine tuning for the new training data

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -271,12 +271,12 @@ class LocusToGeneConfig(StepConfig):
     hyperparameters: dict[str, Any] = field(
         default_factory=lambda: {
             "n_estimators": 100,
-            "max_depth": 10,
+            "max_depth": 3,
             "ccp_alpha": 0,
             "learning_rate": 0.1,
-            "min_samples_leaf": 5,
+            "min_samples_leaf": 1,
             "min_samples_split": 5,
-            "subsample": 1,
+            "subsample": 0.7,
         }
     )
     wandb_run_name: str | None = None


### PR DESCRIPTION
## ✨ Context
We have re run another round of hyperparam tuning on this grid of params (2916 total combinations):
```
params = {
    'learning_rate': [0.01, 0.1, 0.5],
    'subsample': [0.5, 0.7, 1.0],
    'max_depth': [3, 5, 7, 10],
    'ccp_alpha': [0.0, 0.001, 0.01],
    'min_samples_leaf': [1, 5, 10],
    'min_samples_split': [2, 5, 10],
    'tol': [0.0001, 0.001, 0.01]
}
```

Based on all results, we have selected the **best params that give the best results in terms of average precision.**

### Cross validation metrics
```
Performing cross-validation...
Fold 1: Average Precision = 0.826
Fold 2: Average Precision = 0.704
Fold 3: Average Precision = 0.870
Fold 4: Average Precision = 0.691
Fold 5: Average Precision = 0.727

Cross-validation Average Precision: 0.763 (+/- 0.142)

 (Config: best) - Training final model on full training set...

(Config: best) -  Evaluating on held-out test set...
(Config: best) - Test Set Average Precision: 0.741
```

### Selectivity in the predictions
Very similar to the results reported for December release.
3.6% of credible sets have more than one gene with a L2G score > 0.5

```
+----+------+
|hits| count|
+----+------+
|   1|396252|
|  >3|   113|
|  <3| 20426|
+----+------+
```

Gold standard used: `gs://genetics-portal-dev-analysis/yt4/20241024_EGL_playground/training_set/patched_training_2503-testrun-1_all_string_extended_EGL_variants.json`
Model is here: `gs://ot-team/irene/l2g/06032025/locus_to_gene_best_model/classifier.skops` ([link hugging face](https://huggingface.co/opentargets/locus_to_gene_best_model))
Predictions are here: `gs://ot-team/irene/l2g/06032025/locus_to_gene_best_model/predictions`

**Importantly, this model is <3Mb again, so I expect Shaps to be calculated swiftly.**
