### PR TITLE
refactor(l2g): make wandb logging optional

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -280,8 +280,8 @@ class LocusToGeneConfig(StepConfig):
         }
     )
     wandb_run_name: str | None = None
-    hf_hub_repo_id: str | None = "opentargets/locus_to_gene"
-    hf_model_commit_message: str | None = "chore: update model"
+    hf_hub_repo_id: str | None = None
+    hf_model_commit_message: str | None = None
     hf_model_version: str | None = None
     download_from_hub: bool = True
     cross_validate: bool = True

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -321,8 +321,9 @@ class LocusToGeneStep:
         if self.features_list is None:
             raise ValueError("Features list is required for model training.")
         # Initialize access to weights and biases
-        wandb_key = access_gcp_secret("wandb-key", "open-targets-genetics-dev")
-        wandb_login(key=wandb_key)
+        if self.wandb_run_name:
+            wandb_key = access_gcp_secret("wandb-key", "open-targets-genetics-dev")
+            wandb_login(key=wandb_key)
 
         # Instantiate classifier and train model
         l2g_model = LocusToGeneModel(

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -107,9 +107,9 @@ class LocusToGeneStep:
         hyperparameters: dict[str, Any],
         download_from_hub: bool,
         cross_validate: bool,
-        wandb_run_name: str,
         credible_set_path: str,
         feature_matrix_path: str,
+        wandb_run_name: str | None = None,
         model_path: str | None = None,
         features_list: list[str] | None = None,
         gold_standard_curation_path: str | None = None,
@@ -129,9 +129,9 @@ class LocusToGeneStep:
             hyperparameters (dict[str, Any]): Hyperparameters for the model
             download_from_hub (bool): Whether to download the model from Hugging Face Hub
             cross_validate (bool): Whether to run cross validation (5-fold by default) to train the model.
-            wandb_run_name (str): Name of the run to track model training in Weights and Biases
             credible_set_path (str): Path to the credible set dataset necessary to build the feature matrix
             feature_matrix_path (str): Path to the L2G feature matrix input dataset
+            wandb_run_name (str | None): Name of the run to track model training in Weights and Biases
             model_path (str | None): Path to the model. It can be either in the filesystem or the name on the Hugging Face Hub (in the form of username/repo_name).
             features_list (list[str] | None): List of features to use to train the model
             gold_standard_curation_path (str | None): Path to the gold standard curation file
@@ -333,7 +333,7 @@ class LocusToGeneStep:
         # Run the training
         trained_model = LocusToGeneTrainer(
             model=l2g_model, feature_matrix=feature_matrix
-        ).train(self.wandb_run_name, cross_validate=self.cross_validate)
+        ).train(wandb_run_name=self.wandb_run_name, cross_validate=self.cross_validate)
 
         # Export the model
         if trained_model.training_data and trained_model.model and self.model_path:

--- a/src/gentropy/method/l2g/trainer.py
+++ b/src/gentropy/method/l2g/trainer.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from matplotlib.axes._axes import Axes
     from shap._explanation import Explanation
     from wandb.sdk.wandb_run import Run
+import logging
 
 
 def reset_wandb_env() -> None:
@@ -88,7 +89,7 @@ class LocusToGeneTrainer:
 
         Raises:
             ValueError: Train data not set, nothing to fit.
-            AssertionError: When x_train_size or y_train_size are not zero.
+            AssertionError: If x_train or y_train are empty matrices
         """
         if (
             self.x_train is not None
@@ -184,7 +185,7 @@ class LocusToGeneTrainer:
 
         Raises:
             RuntimeError: If dependencies are not available.
-            AssertionError: When x_train_size or y_train_size are not zero.
+            AssertionError: If x_train or y_train are empty matrices
         """
         if (
             self.x_train is None
@@ -220,36 +221,10 @@ class LocusToGeneTrainer:
             is_binary=True,
         )
         # Track evaluation metrics
-        self.run.log(
-            {
-                "areaUnderROC": roc_auc_score(
-                    self.y_test, y_probas[:, 1], average="weighted"
-                )
-            }
+        metrics = self.evaluate(
+            y_true=self.y_test, y_pred=y_predicted, y_pred_proba=y_probas
         )
-        self.run.log({"accuracy": accuracy_score(self.y_test, y_predicted)})
-        self.run.log(
-            {
-                "weightedPrecision": precision_score(
-                    self.y_test, y_predicted, average="weighted"
-                )
-            }
-        )
-        self.run.log(
-            {
-                "averagePrecision": average_precision_score(
-                    self.y_test, y_predicted, average="weighted"
-                )
-            }
-        )
-        self.run.log(
-            {
-                "weightedRecall": recall_score(
-                    self.y_test, y_predicted, average="weighted"
-                )
-            }
-        )
-        self.run.log({"f1": f1_score(self.y_test, y_predicted, average="weighted")})
+        self.run.log(metrics)
         # Track gold standards and their features
         self.run.log(
             {"featureMatrix": Table(dataframe=self.feature_matrix._df.toPandas())}
@@ -286,9 +261,21 @@ class LocusToGeneTrainer:
         wandb_termlog("Logged Shapley contributions.")
         self.run.finish()
 
+    def log_to_terminal(
+        self: LocusToGeneTrainer, eval_id: str, metrics: dict[str, Any]
+    ) -> None:
+        """Log metrics to terminal.
+
+        Args:
+            eval_id (str): Name of the evaluation set
+            metrics (dict[str, Any]): Model metrics
+        """
+        for metric, value in metrics.items():
+            logging.info("(%s) %s: %s", eval_id, metric, value)
+
     def train(
         self: LocusToGeneTrainer,
-        wandb_run_name: str,
+        wandb_run_name: str | None = None,
         cross_validate: bool = True,
         n_splits: int = 5,
         hyperparameter_grid: dict[str, Any] | None = None,
@@ -302,7 +289,7 @@ class LocusToGeneTrainer:
             4. Evaluate once on test set
 
         Args:
-            wandb_run_name (str): Name of the W&B run. Unless this is provided, the model will not be logged to W&B.
+            wandb_run_name (str | None): Name of the W&B run. Unless this is provided, the model will not be logged to W&B.
             cross_validate (bool): Whether to run cross-validation. Defaults to True.
             n_splits(int): Number of folds the data is splitted in. The model is trained and evaluated `k - 1` times. Defaults to 5.
             hyperparameter_grid (dict[str, Any] | None): Hyperparameter grid to sweep over. Defaults to None.
@@ -343,39 +330,62 @@ class LocusToGeneTrainer:
         self.fit()
 
         # Evaluate once on hold out test set
-        self.log_to_wandb(
-            wandb_run_name=f"{wandb_run_name}-holdout",
-        )
+        if wandb_run_name:
+            wandb_run_name = f"{wandb_run_name}-holdout"
+            self.log_to_wandb(wandb_run_name)
+        else:
+            self.log_to_terminal(
+                eval_id="Hold-out",
+                metrics=self.evaluate(
+                    y_true=self.y_test,
+                    y_pred=self.model.model.predict(self.x_test),
+                    y_pred_proba=self.model.model.predict_proba(self.x_test),
+                ),
+            )
 
         return self.model
 
     def cross_validate(
         self: LocusToGeneTrainer,
-        wandb_run_name: str,
+        wandb_run_name: str | None = None,
         parameter_grid: dict[str, Any] | None = None,
         n_splits: int = 5,
     ) -> None:
         """Log results of cross validation and hyperparameter tuning with W&B Sweeps. Metrics for every combination of hyperparameters will be logged to W&B for comparison.
 
         Args:
-            wandb_run_name (str): Name of the W&B run
+            wandb_run_name (str | None): Name of the W&B run. Unless this is provided, the model will not be logged to W&B.
             parameter_grid (dict[str, Any] | None): Dictionary containing the hyperparameters to sweep over. The keys are the hyperparameter names, and the values are dictionaries containing the values to sweep over.
             n_splits (int): Number of folds the data is splitted in. The model is trained and evaluated `k - 1` times. Defaults to 5.
         """
+        # If no grid is provided, use default ones set in the model
+        parameter_grid = parameter_grid or {
+            param: {"values": [value]}
+            for param, value in self.model.hyperparameters.items()
+        }
+        sweep_config = {
+            "method": "grid",
+            "name": wandb_run_name,  # Add name to sweep config
+            "metric": {"name": "areaUnderROC", "goal": "maximize"},
+            "parameters": parameter_grid,
+        }
+        sweep_id = wandb_sweep(
+            sweep_config, project=self.wandb_l2g_project_name
+        )  # TODO
 
         def cross_validate_single_fold(
             fold_index: int,
-            sweep_id: str,
-            sweep_run_name: str,
-            config: dict[str, Any],
+            sweep_id: str | None,
+            sweep_run_name: str | None,
+            config: dict[str, Any] | None,
         ) -> None:
             """Run cross-validation for a single fold.
 
             Args:
                 fold_index (int): Index of the fold to run
-                sweep_id (str): ID of the sweep
-                sweep_run_name (str): Name of the sweep run
-                config (dict[str, Any]): Configuration from the sweep
+                sweep_id (str | None): ID of the sweep, if logging to W&B is enabled
+                sweep_run_name (str | None): Name of the sweep run, if logging to W&B is enabled
+                config (dict[str, Any] | None): Configuration from the sweep, if logging to W&B is enabled
 
             Raises:
                 ValueError: If training data is not set
@@ -390,17 +400,6 @@ class LocusToGeneTrainer:
             ):
                 raise ValueError("Training data not set")
 
-            # Initialize a new run for this fold
-            os.environ["WANDB_SWEEP_ID"] = sweep_id
-            run = wandb_init(
-                project=self.wandb_l2g_project_name,
-                name=sweep_run_name,
-                config=config,
-                group=sweep_run_name,
-                job_type="fold",
-                reinit=True,
-            )
-
             x_fold_train, x_fold_val = (
                 self.x_train[train_idx],
                 self.x_train[val_idx],
@@ -411,66 +410,97 @@ class LocusToGeneTrainer:
             )
 
             fold_model = clone(self.model.model)
-            fold_model.set_params(**config)
             fold_model.fit(x_fold_train, y_fold_train)
             y_pred_proba = fold_model.predict_proba(x_fold_val)[:, 1]
             y_pred = (y_pred_proba >= 0.5).astype(int)
 
             # Log metrics
-            metrics = {
-                "weightedPrecision": precision_score(y_fold_val, y_pred),
-                "averagePrecision": average_precision_score(y_fold_val, y_pred_proba),
-                "areaUnderROC": roc_auc_score(y_fold_val, y_pred_proba),
-                "accuracy": accuracy_score(y_fold_val, y_pred),
-                "weightedRecall": recall_score(y_fold_val, y_pred, average="weighted"),
-                "f1": f1_score(y_fold_val, y_pred, average="weighted"),
-            }
-
-            run.log(metrics)
-            wandb_termlog(f"Logged metrics for fold {fold_index + 1}.")
-            run.finish()
-
-        # If no grid is provided, use default ones set in the model
-        parameter_grid = parameter_grid or {
-            param: {"values": [value]}
-            for param, value in self.model.hyperparameters.items()
-        }
-        sweep_config = {
-            "method": "grid",
-            "name": wandb_run_name,  # Add name to sweep config
-            "metric": {"name": "areaUnderROC", "goal": "maximize"},
-            "parameters": parameter_grid,
-        }
-        sweep_id = wandb_sweep(sweep_config, project=self.wandb_l2g_project_name)
+            metrics = self.evaluate(
+                y_true=y_fold_val, y_pred=y_pred, y_pred_proba=y_pred_proba
+            )
+            if sweep_id and sweep_run_name and config:
+                fold_model.set_params(**config)
+                # Initialize a new run for this fold
+                os.environ["WANDB_SWEEP_ID"] = sweep_id
+                run = wandb_init(
+                    project=self.wandb_l2g_project_name,
+                    name=sweep_run_name,
+                    config=config,
+                    group=sweep_run_name,
+                    job_type="fold",
+                    reinit=True,
+                )
+                run.log(metrics)
+                wandb_termlog(f"Logged metrics for fold {fold_index + 1}.")
+                run.finish()
+            else:
+                self.log_to_terminal(eval_id=f"Fold {fold_index+1}", metrics=metrics)
 
         gkf = GroupKFold(n_splits=n_splits)
         cv_splits = list(gkf.split(self.x_train, self.y_train, self.groups_train))
 
         def run_all_folds() -> None:
-            """Run cross-validation for all folds within a sweep."""
-            # Initialize the sweep run and get metadata
-            sweep_run = wandb_init(name=wandb_run_name)
-            sweep_id = sweep_run.sweep_id or "unknown"
-            sweep_url = sweep_run.get_sweep_url()
-            project_url = sweep_run.get_project_url()
-            sweep_group_url = f"{project_url}/groups/{sweep_id}"
-            sweep_run.notes = sweep_group_url
-            sweep_run.save()
-            config = dict(sweep_run.config)
+            """Run cross-validation for all folds."""
+            sweep_run = None
+            if wandb_run_name:
+                # Initialize the sweep run and get metadata
+                sweep_run = wandb_init(name=wandb_run_name)
+                sweep_id = sweep_run.sweep_id
+                sweep_url = sweep_run.get_sweep_url()
+                sweep_group_url = f"{sweep_run.get_project_url()}/groups/{sweep_id}"
+                sweep_run.notes = sweep_group_url
+                sweep_run.save()
+                config = dict(sweep_run.config)
 
-            # Reset wandb setup to ensure clean state
-            _setup(_reset=True)
+                # Reset wandb setup to ensure clean state
+                _setup(_reset=True)
+
+                wandb_termlog(f"Sweep URL: {sweep_url}")
+                wandb_termlog(f"Sweep Group URL: {sweep_group_url}")
 
             # Run all folds
             for fold_index in range(len(cv_splits)):
                 cross_validate_single_fold(
                     fold_index=fold_index,
-                    sweep_id=sweep_id,
-                    sweep_run_name=f"{wandb_run_name}-fold{fold_index + 1}",
-                    config=config,
+                    sweep_id=sweep_id if sweep_id else None,
+                    sweep_run_name=f"{wandb_run_name}-fold{fold_index + 1}"
+                    if wandb_run_name
+                    else None,
+                    config=config if config else None,
                 )
 
-            wandb_termlog(f"Sweep URL: {sweep_url}")
-            wandb_termlog(f"Sweep Group URL: {sweep_group_url}")
+        if wandb_run_name:
+            # Evaluate with cross validation in a W&B Sweep
+            wandb_agent(sweep_id, run_all_folds)
+        else:
+            # Evaluate with cross validation to the terminal
+            run_all_folds()
 
-        wandb_agent(sweep_id, run_all_folds)
+    def evaluate(
+        self: LocusToGeneTrainer,
+        y_true: np.ndarray,
+        y_pred: np.ndarray,
+        y_pred_proba: np.ndarray,
+    ) -> dict[str, float]:
+        """Evaluate the model on a test set.
+
+        Args:
+            y_true (np.ndarray): True labels
+            y_pred (np.ndarray): Predicted labels
+            y_pred_proba (np.ndarray): Predicted probabilities for the positive class
+
+        Returns:
+            dict[str, float]: Dictionary of evaluation metrics
+        """
+        return {
+            "areaUnderROC": roc_auc_score(
+                y_true, y_pred_proba[:, 1], average="weighted"
+            ),
+            "accuracy": accuracy_score(y_true, y_pred),
+            "weightedPrecision": precision_score(y_true, y_pred, average="weighted"),
+            "averagePrecision": average_precision_score(
+                y_true, y_pred, average="weighted"
+            ),
+            "weightedRecall": recall_score(y_true, y_pred, average="weighted"),
+            "f1": f1_score(y_true, y_pred, average="weighted"),
+        }

--- a/tests/gentropy/conftest.py
+++ b/tests/gentropy/conftest.py
@@ -655,14 +655,22 @@ def sample_otp_interactions(spark: SparkSession) -> DataFrame:
 
 @pytest.fixture()
 def mock_l2g_feature_matrix(spark: SparkSession) -> L2GFeatureMatrix:
-    """Mock l2g feature matrix dataset."""
+    """Mock l2g feature matrix dataset with multiple samples from each class."""
     return L2GFeatureMatrix(
         _df=spark.createDataFrame(
             [
-                ("1", "gene1", 100.0, None, True),
-                ("2", "gene2", 1000.0, 0.0, False),
+                # Multiple samples for "positive" class
+                ("1", "gene1", "trait1", 100.0, None, "positive"),
+                ("2", "gene2", "trait1", 200.0, 20.0, "positive"),
+                ("3", "gene3", "trait2", 300.0, 30.0, "positive"),
+                ("4", "gene4", "trait2", 400.0, 40.0, "positive"),
+                # Multiple samples for "negative" class
+                ("5", "gene5", "trait1", 500.0, 50.0, "negative"),
+                ("6", "gene6", "trait1", 600.0, 60.0, "negative"),
+                ("7", "gene7", "trait2", 700.0, 70.0, "negative"),
+                ("8", "gene8", "trait2", 800.0, 80.0, "negative"),
             ],
-            "studyLocusId STRING, geneId STRING, distanceTssMean FLOAT, distanceSentinelTssMinimum FLOAT, goldStandardSet BOOLEAN",
+            "studyLocusId STRING, geneId STRING, traitFromSourceMappedId STRING, distanceTssMean FLOAT, distanceSentinelTssMinimum FLOAT, goldStandardSet STRING",
         ),
         with_gold_standard=True,
     )

--- a/tests/gentropy/dataset/test_l2g.py
+++ b/tests/gentropy/dataset/test_l2g.py
@@ -177,10 +177,10 @@ def test_l2g_feature_constructor_with_schema_mismatch(
 
 
 def test_calculate_feature_missingness_rate(
-    spark: SparkSession, mock_l2g_feature_matrix: L2GFeatureMatrix
+    mock_l2g_feature_matrix: L2GFeatureMatrix,
 ) -> None:
     """Test L2GFeatureMatrix.calculate_feature_missingness_rate."""
-    expected_missingness = {"distanceTssMean": 0.0, "distanceSentinelTssMinimum": 1.0}
+    expected_missingness = {"distanceTssMean": 0.0, "distanceSentinelTssMinimum": 0.125}
     observed_missingness = mock_l2g_feature_matrix.calculate_feature_missingness_rate()
     assert isinstance(observed_missingness, dict)
     assert mock_l2g_feature_matrix.features_list is not None and len(

--- a/tests/gentropy/method/test_l2g_trainer.py
+++ b/tests/gentropy/method/test_l2g_trainer.py
@@ -1,0 +1,75 @@
+"""Tests on L2G trainer."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from sklearn.ensemble import GradientBoostingClassifier
+
+from gentropy.method.l2g.model import LocusToGeneModel
+from gentropy.method.l2g.trainer import LocusToGeneTrainer
+
+if TYPE_CHECKING:
+    from gentropy.dataset.l2g_feature_matrix import L2GFeatureMatrix
+
+
+def test_evaluate_perfect_predictions() -> None:
+    """Test function with perfect predictions."""
+    y_true = np.array([0, 1, 0, 1])
+    y_pred = np.array([0, 1, 0, 1])
+    y_pred_proba = np.array(
+        [
+            [0.9, 0.1],
+            [0.1, 0.9],
+            [0.9, 0.1],
+            [0.1, 0.9],
+        ]
+    )
+
+    metrics = LocusToGeneTrainer.evaluate(y_true, y_pred, y_pred_proba)
+    expected = {
+        "areaUnderROC": 1.0,
+        "averagePrecision": 1.0,
+        "accuracy": 1.0,
+        "weightedPrecision": 1.0,
+        "weightedRecall": 1.0,
+        "f1": 1.0,
+    }
+    assert metrics == expected
+
+
+def test_train_no_cross_validation(mock_l2g_feature_matrix: L2GFeatureMatrix) -> None:
+    """Test LocusToGeneTrainer.train without cross validation."""
+    # Mock simple model
+    features_list = ["distanceTssMean", "distanceSentinelTssMinimum"]
+    l2g_model = LocusToGeneModel(
+        model=GradientBoostingClassifier(),
+        hyperparameters={"random_state": 42, "loss": "log_loss"},
+        features_list=features_list,
+    )
+    trainer = LocusToGeneTrainer(
+        model=l2g_model,
+        feature_matrix=mock_l2g_feature_matrix.fill_na(),
+        features_list=features_list,
+    )
+    trained_model = trainer.train(wandb_run_name=None, cross_validate=False)
+    assert isinstance(trained_model, LocusToGeneModel)
+
+
+def test_train_cross_validation(mock_l2g_feature_matrix: L2GFeatureMatrix) -> None:
+    """Test LocusToGeneTrainer.train without cross validation."""
+    # Mock simple model
+    features_list = ["distanceTssMean", "distanceSentinelTssMinimum"]
+    l2g_model = LocusToGeneModel(
+        model=GradientBoostingClassifier(),
+        hyperparameters={"random_state": 42, "loss": "log_loss"},
+        features_list=features_list,
+    )
+    trainer = LocusToGeneTrainer(
+        model=l2g_model,
+        feature_matrix=mock_l2g_feature_matrix.fill_na(),
+        features_list=features_list,
+    )
+    trained_model = trainer.train(wandb_run_name=None, cross_validate=True)
+    assert isinstance(trained_model, LocusToGeneModel)


### PR DESCRIPTION
## ✨ Context
Closes https://github.com/opentargets/issues/issues/3440#issue-2507945734

## 🛠 What does this PR implement
- `wandb_run_name` is now nullable in the L2G Step Config
- Added `LocusToGeneTrainer.evaluate` to extract metrics. This method is now used by several functions, depending whether or not you log to W&B
- Refactor of ` LocusToGeneTrainer.cross_validate` to make it independent of the W&B API
- Added tests for the L2G trainer to make sure the `train` method works on dummy data
- `hf_repo_id` and ` hf_commit_message`  are no longer set by default. This is because when you set these params to null in the orchestration, the null is not interpreted correctly and it was trying to save the model using `https://huggingface.co/api/models/None/preupload/main`

## 🙈 Missing

Testing the approach on W&B with cross validation on.

## 🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the `dev` branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (`make test`)?
- [x] Did you make sure the changes pass pre-commit rules (e.g `uv run pre-commit run --all-files`)?
