### PR TITLE
Fix: Ensure `qualityControls` and `analysisFlags` columns are always added when `curation_table` is None

### DIFF
--- a/src/gentropy/datasource/gwas_catalog/study_index.py
+++ b/src/gentropy/datasource/gwas_catalog/study_index.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import pyspark.sql.functions as f
 import pyspark.sql.types as t
+from pyspark.sql.types import ArrayType, StringType
 
 from gentropy.common.spark_helpers import column2camel_case
 from gentropy.common.utils import parse_efos
@@ -353,10 +354,14 @@ class StudyIndexGWASCatalog(StudyIndex):
         studies = self.df
 
         if "qualityControls" not in studies.columns:
-            studies = studies.withColumn("qualityControls", f.array())
+            studies = studies.withColumn(
+                "qualityControls", f.array().cast(ArrayType(StringType()))
+            )
 
         if "analysisFlags" not in studies.columns:
-            studies = studies.withColumn("analysisFlags", f.array())
+            studies = studies.withColumn(
+                "analysisFlags", f.array().cast(ArrayType(StringType()))
+            )
 
         # Providing curation table is optional. However once this method is called, the quality and studyFlag columns are added.
         if curation_table is None:

--- a/src/gentropy/datasource/gwas_catalog/study_index.py
+++ b/src/gentropy/datasource/gwas_catalog/study_index.py
@@ -350,10 +350,6 @@ class StudyIndexGWASCatalog(StudyIndex):
         Returns:
             StudyIndexGWASCatalog: Updated study index
         """
-        # Providing curation table is optional. However once this method is called, the quality and studyFlag columns are added.
-        if curation_table is None:
-            return self
-
         studies = self.df
 
         if "qualityControls" not in studies.columns:
@@ -361,6 +357,12 @@ class StudyIndexGWASCatalog(StudyIndex):
 
         if "analysisFlags" not in studies.columns:
             studies = studies.withColumn("analysisFlags", f.array())
+
+        # Providing curation table is optional. However once this method is called, the quality and studyFlag columns are added.
+        if curation_table is None:
+            return StudyIndexGWASCatalog(
+                _df=studies, _schema=StudyIndexGWASCatalog.get_schema()
+            )
 
         # Adding prefix to columns in the curation table:
         curation_table = curation_table.select(


### PR DESCRIPTION
## ✨ Context

Previously, when `curation_table` was `None`, the `qualityControls` and `analysisFlags` columns were not being added as intended. This could lead to inconsistencies when handling study data. The fix ensures that these columns are always present, even when no curation table is provided.  

## 🛠 What does this PR implement  

- Ensures that `qualityControls` and `analysisFlags` columns are always added to `studies` before checking for `curation_table`.  
- Returns a new `StudyIndexGWASCatalog` object instead of `self` when `curation_table` is `None`, preserving the modified DataFrame with the added columns.  

## 🙈 Missing  

Nothing—this PR fully implements the intended fix.  

## 🚦 Before submitting  

- [x] Do these changes cover one single feature (one change at a time)?  
- [x] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?  
- [x] Did you make sure to update the documentation with your changes?  
- [x] Did you make sure there is no commented-out code in this PR?  
- [x] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?  
- [x] Did you make sure the branch is up-to-date with the `dev` branch?  
- [x] Did you write any new necessary tests?  
- [x] Did you make sure the changes pass local tests (`make test`)?  
- [x] Did you make sure the changes pass pre-commit rules (e.g., `uv run pre-commit run --all-files`)?  

