### PR TITLE
fix(l2g): half of the feature matrix have distance features larger than 1

### DIFF
--- a/src/gentropy/dataset/l2g_features/distance.py
+++ b/src/gentropy/dataset/l2g_features/distance.py
@@ -51,13 +51,13 @@ def common_distance_feature_logic(
             f.col("variantInLocus.posteriorProbability").alias("posteriorProbability"),
         )
         distance_score_expr = (
-            f.lit(genomic_window) - f.col(distance_type) + f.lit(1)
+            f.lit(genomic_window) - f.abs(distance_type) + f.lit(1)
         ) * f.col("posteriorProbability")
         agg_expr = f.sum(f.col("distance_score"))
     elif "Sentinel" in feature_name:
         df = study_loci_to_annotate.df.select("studyLocusId", "variantId")
         # For minimum distances we calculate the unweighted distance between the sentinel (lead) and the gene.
-        distance_score_expr = f.lit(genomic_window) - f.col(distance_type) + f.lit(1)
+        distance_score_expr = f.lit(genomic_window) - f.abs(distance_type) + f.lit(1)
         agg_expr = f.first(f.col("distance_score"))
     return (
         df.join(


### PR DESCRIPTION
I've modeled the solution by looking at this example:
```
+-------------+---------------+---------------+---------------------+
|    variantId|       targetId|distanceFromTss|distanceFromFootprint|
+-------------+---------------+---------------+---------------------+
|16_975464_G_A|ENSG00000103266|        -295054|               292663|
+-------------+---------------+---------------+---------------------+

distance_score_expr = f.lit(500_000) - f.col("distanceFromTss") + f.lit(1)

df = df.withColumn(
            "distance_score",
            distance_score_expr,
        ).withColumn(
            "distanceSentinelTss",
            f.log10(f.col("distance_score")) / f.log10(f.lit(500_000 + 1)),
        )

df.show()
+-------------+---------------+---------------+---------------------+--------------+-------------------+
|    variantId|       targetId|distanceFromTss|distanceFromFootprint|distance_score|distanceSentinelTss|
+-------------+---------------+---------------+---------------------+--------------+-------------------+
|16_975464_G_A|ENSG00000103266|        -295054|               292663|        795055| 1.0353443287770194|
+-------------+---------------+---------------+---------------------+--------------+-------------------+
```

The issue arises when we have a negative distance value (variant downstream), as subtracting a negative number in the normalisation expression becomes an addition, results in a distance score larger than our intended maximum of 500,001. Taking the absolute distance solves the issue.

This is widespread across the FM and requires a rerun.
