### PR TITLE
feat: adding pmid to finngen studies

### DIFF
--- a/src/gentropy/datasource/finngen/study_index.py
+++ b/src/gentropy/datasource/finngen/study_index.py
@@ -33,12 +33,12 @@ class FinnGenStudyIndex:
     Some fields are also populated as constants, such as study type and the initial sample size.
     """
 
-    CONSTANTS = [
-        f.lit("gwas").alias("studyType"),
-        f.lit(True).alias("hasSumstats"),
-        f.lit("500,348 (282,064 females and 218,284 males)").alias("initialSampleSize"),
-        f.lit("36653562").alias("pubmedId"),
-    ]
+    CONSTANTS = {
+        "studyType": "gwas",
+        "hasSumstats": True,
+        "initialSampleSize": "500,348 (282,064 females and 218,284 males)",
+        "pubmedId": "36653562",
+    }
 
     @staticmethod
     def validate_release_prefix(release_prefix: str) -> FinngenPrefixMatch:
@@ -183,7 +183,7 @@ class FinnGenStudyIndex:
                     f.lit(finngen_summary_stats_url_suffix),
                 ).alias("summarystatsLocation"),
                 f.lit(finngen_release_prefix).alias("projectId"),
-                *cls.CONSTANTS,
+                *[f.lit(value).alias(key) for key, value in cls.CONSTANTS.items()],
             ).withColumn(
                 "ldPopulationStructure",
                 StudyIndex.aggregate_and_map_ancestries(f.col("discoverySamples")),

--- a/src/gentropy/datasource/finngen/study_index.py
+++ b/src/gentropy/datasource/finngen/study_index.py
@@ -33,6 +33,13 @@ class FinnGenStudyIndex:
     Some fields are also populated as constants, such as study type and the initial sample size.
     """
 
+    CONSTANTS = [
+        f.lit("gwas").alias("studyType"),
+        f.lit(True).alias("hasSumstats"),
+        f.lit("500,348 (282,064 females and 218,284 males)").alias("initialSampleSize"),
+        f.lit("36653562").alias("pubmedId"),
+    ]
+
     @staticmethod
     def validate_release_prefix(release_prefix: str) -> FinngenPrefixMatch:
         """Validate release prefix passed to finngen StudyIndex.
@@ -162,12 +169,6 @@ class FinnGenStudyIndex:
                 (f.col("num_cases") + f.col("num_controls"))
                 .cast("integer")
                 .alias("nSamples"),
-                f.lit(finngen_release_prefix).alias("projectId"),
-                f.lit("gwas").alias("studyType"),
-                f.lit(True).alias("hasSumstats"),
-                f.lit("500,348 (282,064 females and 218,284 males)").alias(
-                    "initialSampleSize"
-                ),
                 f.array(
                     f.struct(
                         f.lit(sample_size).cast("integer").alias("sampleSize"),
@@ -181,6 +182,8 @@ class FinnGenStudyIndex:
                     f.col("phenocode"),
                     f.lit(finngen_summary_stats_url_suffix),
                 ).alias("summarystatsLocation"),
+                f.lit(finngen_release_prefix).alias("projectId"),
+                *cls.CONSTANTS,
             ).withColumn(
                 "ldPopulationStructure",
                 StudyIndex.aggregate_and_map_ancestries(f.col("discoverySamples")),


### PR DESCRIPTION
## ✨ Context

Finngen data releases are not tied to publications, therefore so far studies from this source were ingested without pmids. This have some unexpected consequences eg. it is not possible to timestamp disease target evidence based on Finngen credible sets. This PR links all R12 finngen studies with ["36653562"](https://pubmed.ncbi.nlm.nih.gov/36653562/), which is the most recent publication of the Finngen core team. 

Also all hard-coded fields of the study index are extracted to the top of the class definition to make it easier to change in the future.
