### PR TITLE
fix(l2g): move `append_null_features` param to feature matrix step

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -287,7 +287,6 @@ class LocusToGeneConfig(StepConfig):
     download_from_hub: bool = True
     cross_validate: bool = True
     explain_predictions: bool | None = False
-    append_null_features: bool = False
     _target_: str = "gentropy.l2g.LocusToGeneStep"
 
 
@@ -350,6 +349,7 @@ class LocusToGeneFeatureMatrixConfig(StepConfig):
             "isProteinCoding",
         ]
     )
+    append_null_features: bool = False
     _target_: str = "gentropy.l2g.LocusToGeneFeatureMatrixStep"
 
 


### PR DESCRIPTION
## ✨ Context
Small bug in the configuration. `append_null_features` was added to the L2G step instead of the Feature Matrix Step
<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [ ] Do these changes cover one single feature (one change at a time)?
- [ ] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [ ] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ ] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `uv run pre-commit run --all-files`)?
