### PR TITLE
feat(l2g): add dark matter loci filter for training set

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -361,6 +361,7 @@ class LocusToGeneConfig(StepConfig):
     explain_predictions: bool = False
     wandb_credentials_path: str | None = None
     hf_credentials_path: str | None = None
+    filter_dark_matter: bool = False
     _target_: str = "gentropy.l2g.LocusToGeneStep"
 
 

--- a/src/gentropy/dataset/l2g_feature_matrix.py
+++ b/src/gentropy/dataset/l2g_feature_matrix.py
@@ -345,6 +345,7 @@ class L2GFeatureMatrix:
             positives.filter(no_signal & not_nearest)
             .groupBy("studyLocusId")
             .agg(f.count("*").alias("dark_matter_count"))
+            .persist()
         )
         dark_matter_loci = (
             total_positives_per_locus.join(
@@ -374,6 +375,7 @@ class L2GFeatureMatrix:
 
         self._df = self._df.join(dark_matter_loci, "studyLocusId", "left_anti")
         dark_matter_loci.unpersist()
+        dark_matter_positives_per_locus.unpersist()
 
         # Consolidate after-stats into a single aggregation (1 action)
         after_row = self._df.agg(

--- a/src/gentropy/dataset/l2g_feature_matrix.py
+++ b/src/gentropy/dataset/l2g_feature_matrix.py
@@ -309,19 +309,22 @@ class L2GFeatureMatrix:
             )
             return self, {}
 
-        # "No functional signal" condition
+        # "No functional signal" condition — coalesce to 0.0 so that NULL
+        # (produced by inner joins when no coloc/VEP evidence exists) is treated
+        # as "no signal" rather than being propagated as NULL by the comparison.
         if qtl_e2g_features:
             no_qtl_e2g_signal = reduce(
-                lambda acc, col: acc & (f.col(col) == 0.0),
+                lambda acc, col: acc & (f.coalesce(f.col(col), f.lit(0.0)) == 0.0),
                 qtl_e2g_features[1:],
-                f.col(qtl_e2g_features[0]) == 0.0,
+                f.coalesce(f.col(qtl_e2g_features[0]), f.lit(0.0)) == 0.0,
             )
         else:
             no_qtl_e2g_signal = f.lit(True)
 
         if "vepMaximum" in self.features_list:
             no_signal = no_qtl_e2g_signal & (
-                f.col("vepMaximum") < self._VEP_PROTEIN_ALTERING_THRESHOLD
+                f.coalesce(f.col("vepMaximum"), f.lit(0.0))
+                < self._VEP_PROTEIN_ALTERING_THRESHOLD
             )
         else:
             no_signal = no_qtl_e2g_signal
@@ -373,7 +376,7 @@ class L2GFeatureMatrix:
             f.sum("dark_matter_count").alias("dm_positives"),
         ).collect()[0]
 
-        self._df = self._df.join(dark_matter_loci, "studyLocusId", "left_anti")
+        self._df = self._df.join(dark_matter_loci, "studyLocusId", "left_anti").persist()
         dark_matter_loci.unpersist()
         dark_matter_positives_per_locus.unpersist()
 
@@ -390,12 +393,12 @@ class L2GFeatureMatrix:
             return round((before - after) / before * 100, 2) if before else 0.0
 
         rows_before = int(before_row["rows"])
-        positives_before = int(before_row["positives"])
+        positives_before = int(before_row["positives"] or 0)
         loci_before = int(before_row["loci"])
         dark_matter_loci_count = int(dm_row["loci_removed"])
         dark_matter_positives_count = int(dm_row["dm_positives"] or 0)
         rows_after = int(after_row["rows"])
-        positives_after = int(after_row["positives"])
+        positives_after = int(after_row["positives"] or 0)
         loci_after = int(after_row["loci"])
 
         stats: dict[str, Any] = {

--- a/src/gentropy/dataset/l2g_feature_matrix.py
+++ b/src/gentropy/dataset/l2g_feature_matrix.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from functools import reduce
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Any, Self
 
 import pyspark.sql.functions as f
 from pandas import DataFrame as pd_dataframe
@@ -224,6 +225,188 @@ class L2GFeatureMatrix:
             self.features_list.extend(null_features)
 
         return self
+
+    # VEP threshold for coding signal. Set to 0.6 (slightly below the computed
+    # score of 0.66 for protein_altering_variant SO:0001818, rank=14/41) to
+    # give a small margin around that boundary.
+    _VEP_PROTEIN_ALTERING_THRESHOLD: float = 0.6
+
+    # Functional genomics signal features for dark matter detection.
+    # A positive with all of these at zero (and vepMaximum below threshold)
+    # has no molecular evidence linking it to the locus.
+    _DARK_MATTER_SIGNAL_FEATURES: list[str] = [
+        "eQtlColocClppMaximum",
+        "pQtlColocClppMaximum",
+        "sQtlColocClppMaximum",
+        "eQtlColocH4Maximum",
+        "pQtlColocH4Maximum",
+        "sQtlColocH4Maximum",
+        "transPQtlColocH4Maximum",
+        "e2gMean",
+    ]
+
+    # Neighbourhood distance features used to determine whether a gene is the
+    # nearest to the sentinel.  A value of 1.0 means the gene is the nearest
+    # in the locus window.  A positive that is nearest by any of these measures
+    # is excluded from dark matter removal even if it has no functional signal,
+    # because its proximity may still make it a learnable positive.
+    _DARK_MATTER_NEAREST_FEATURES: list[str] = [
+        "distanceSentinelFootprintNeighbourhood",
+        "distanceFootprintMeanNeighbourhood",
+        "distanceTssMeanNeighbourhood",
+        "distanceSentinelTssNeighbourhood",
+    ]
+
+    def filter_dark_matter_loci(self: Self) -> tuple[Self, dict[str, Any]]:
+        """Remove all loci that contain at least one dark matter positive.
+
+        Dark matter positives are gold-standard positives that satisfy both:
+        - No functional genomics signal: all QTL colocalisation features and
+          e2gMean are zero, and vepMaximum (when present) is below the
+          protein-altering threshold (0.6).
+        - Not the nearest gene: all neighbourhood distance features are < 1.0.
+
+        Positives that are the nearest gene (any neighbourhood distance = 1.0)
+        are kept even without functional signal. A locus is only removed when
+        ALL of its positives are dark matter. The entire locus (positives and
+        negatives) is dropped so class balance within retained loci is preserved.
+
+        Returns:
+            tuple[Self, dict[str, Any]]: Filtered feature matrix and a stats
+                dict with before/after counts and reduction percentages.
+
+        Raises:
+            ValueError: If called on a feature matrix without gold standard labels.
+        """
+        if not self.with_gold_standard:
+            raise ValueError(
+                "Dark matter filtering requires a gold standard-annotated feature matrix."
+            )
+
+        # Only check features actually present in this matrix
+        qtl_e2g_features = [
+            col
+            for col in self._DARK_MATTER_SIGNAL_FEATURES
+            if col in self.features_list
+        ]
+        nearest_features = [
+            col
+            for col in self._DARK_MATTER_NEAREST_FEATURES
+            if col in self.features_list
+        ]
+
+        if not qtl_e2g_features and "vepMaximum" not in self.features_list:
+            logging.warning(
+                "No dark matter signal features found in feature matrix; "
+                "filter has no effect."
+            )
+            empty_stats: dict[str, Any] = {}
+            return self, empty_stats
+
+        # "No functional signal" condition
+        if qtl_e2g_features:
+            no_qtl_e2g_signal = reduce(
+                lambda acc, col: acc & (f.col(col) == 0.0),
+                qtl_e2g_features[1:],
+                f.col(qtl_e2g_features[0]) == 0.0,
+            )
+        else:
+            no_qtl_e2g_signal = f.lit(True)
+
+        if "vepMaximum" in self.features_list:
+            no_signal = no_qtl_e2g_signal & (
+                f.col("vepMaximum") < self._VEP_PROTEIN_ALTERING_THRESHOLD
+            )
+        else:
+            no_signal = no_qtl_e2g_signal
+
+        # "Not the nearest gene" condition — all neighbourhood distances < 1.0
+        if nearest_features:
+            not_nearest = reduce(
+                lambda acc, col: acc & (f.col(col) < 1.0),
+                nearest_features[1:],
+                f.col(nearest_features[0]) < 1.0,
+            )
+        else:
+            not_nearest = f.lit(True)
+
+        positives = self._df.filter(
+            f.col(self.label_col) == L2GGoldStandard.GS_POSITIVE_LABEL
+        )
+
+        # Count all positives per locus and dark matter positives per locus separately,
+        # then only mark a locus for removal when every positive in it is dark matter.
+        total_positives_per_locus = positives.groupBy("studyLocusId").agg(
+            f.count("*").alias("total_positive_count")
+        )
+        dark_matter_positives_per_locus = (
+            positives.filter(no_signal & not_nearest)
+            .groupBy("studyLocusId")
+            .agg(f.count("*").alias("dark_matter_count"))
+        )
+        dark_matter_loci = (
+            total_positives_per_locus.join(
+                dark_matter_positives_per_locus, "studyLocusId"
+            )
+            .filter(f.col("dark_matter_count") == f.col("total_positive_count"))
+            .select("studyLocusId")
+            .persist()
+        )
+
+        # --- Stats: before ---
+        rows_before = self._df.count()
+        positives_before = positives.count()
+        loci_before = self._df.select("studyLocusId").distinct().count()
+        dark_matter_positives_count = positives.filter(no_signal & not_nearest).count()
+        dark_matter_loci_count = dark_matter_loci.count()
+
+        self._df = self._df.join(dark_matter_loci, "studyLocusId", "left_anti")
+        dark_matter_loci.unpersist()
+
+        # --- Stats: after ---
+        rows_after = self._df.count()
+        positives_after = (
+            self._df.filter(
+                f.col(self.label_col) == L2GGoldStandard.GS_POSITIVE_LABEL
+            ).count()
+        )
+        loci_after = self._df.select("studyLocusId").distinct().count()
+
+        def _pct_reduction(before: int, after: int) -> float:
+            return round((before - after) / before * 100, 2) if before else 0.0
+
+        stats: dict[str, Any] = {
+            "before": {
+                "rows": rows_before,
+                "positives": positives_before,
+                "study_locus_ids": loci_before,
+            },
+            "dark_matter": {
+                "positive_rows": dark_matter_positives_count,
+                "study_locus_ids_removed": dark_matter_loci_count,
+            },
+            "after": {
+                "rows": rows_after,
+                "positives": positives_after,
+                "study_locus_ids": loci_after,
+            },
+            "pct_reduction": {
+                "rows": _pct_reduction(rows_before, rows_after),
+                "positives": _pct_reduction(positives_before, positives_after),
+                "study_locus_ids": _pct_reduction(loci_before, loci_after),
+            },
+        }
+
+        logging.info(
+            "Dark matter filter: removed %d loci (%d dark matter positives). "
+            "Training set: %d → %d rows (%.1f%% reduction).",
+            dark_matter_loci_count,
+            dark_matter_positives_count,
+            rows_before,
+            rows_after,
+            stats["pct_reduction"]["rows"],
+        )
+        return self, stats
 
     def generate_train_test_split(
         self,

--- a/src/gentropy/dataset/l2g_feature_matrix.py
+++ b/src/gentropy/dataset/l2g_feature_matrix.py
@@ -258,18 +258,18 @@ class L2GFeatureMatrix:
     ]
 
     def filter_dark_matter_loci(self: Self) -> tuple[Self, dict[str, Any]]:
-        """Remove all loci that contain at least one dark matter positive.
+        """Remove all loci whose every positive is a dark matter positive.
 
-        Dark matter positives are gold-standard positives that satisfy both:
+        A dark matter positive is a gold-standard positive that satisfies both:
         - No functional genomics signal: all QTL colocalisation features and
           e2gMean are zero, and vepMaximum (when present) is below the
           protein-altering threshold (0.6).
         - Not the nearest gene: all neighbourhood distance features are < 1.0.
 
-        Positives that are the nearest gene (any neighbourhood distance = 1.0)
-        are kept even without functional signal. A locus is only removed when
-        ALL of its positives are dark matter. The entire locus (positives and
-        negatives) is dropped so class balance within retained loci is preserved.
+        A locus is removed only when ALL of its positives are dark matter.
+        Loci with at least one signal-carrying or nearest-gene positive are
+        kept. The entire locus (positives and negatives) is dropped so class
+        balance within retained loci is preserved.
 
         Returns:
             tuple[Self, dict[str, Any]]: Filtered feature matrix and a stats
@@ -300,8 +300,14 @@ class L2GFeatureMatrix:
                 "No dark matter signal features found in feature matrix; "
                 "filter has no effect."
             )
-            empty_stats: dict[str, Any] = {}
-            return self, empty_stats
+            return self, {}
+
+        if not nearest_features:
+            logging.warning(
+                "No neighbourhood distance features found in feature matrix; "
+                "cannot determine gene nearness — dark matter filter has no effect."
+            )
+            return self, {}
 
         # "No functional signal" condition
         if qtl_e2g_features:
@@ -320,22 +326,18 @@ class L2GFeatureMatrix:
         else:
             no_signal = no_qtl_e2g_signal
 
-        # "Not the nearest gene" condition — all neighbourhood distances < 1.0
-        if nearest_features:
-            not_nearest = reduce(
-                lambda acc, col: acc & (f.col(col) < 1.0),
-                nearest_features[1:],
-                f.col(nearest_features[0]) < 1.0,
-            )
-        else:
-            not_nearest = f.lit(True)
+        # "Not the nearest gene" — all neighbourhood distances < 1.0
+        not_nearest = reduce(
+            lambda acc, col: acc & (f.col(col) < 1.0),
+            nearest_features[1:],
+            f.col(nearest_features[0]) < 1.0,
+        )
 
         positives = self._df.filter(
             f.col(self.label_col) == L2GGoldStandard.GS_POSITIVE_LABEL
         )
 
-        # Count all positives per locus and dark matter positives per locus separately,
-        # then only mark a locus for removal when every positive in it is dark matter.
+        # Mark a locus for removal only when every positive in it is dark matter.
         total_positives_per_locus = positives.groupBy("studyLocusId").agg(
             f.count("*").alias("total_positive_count")
         )
@@ -353,27 +355,46 @@ class L2GFeatureMatrix:
             .persist()
         )
 
-        # --- Stats: before ---
-        rows_before = self._df.count()
-        positives_before = positives.count()
-        loci_before = self._df.select("studyLocusId").distinct().count()
-        dark_matter_positives_count = positives.filter(no_signal & not_nearest).count()
-        dark_matter_loci_count = dark_matter_loci.count()
+        # Consolidate before-stats into a single aggregation (3 metrics, 1 action)
+        before_row = self._df.agg(
+            f.count("*").alias("rows"),
+            f.sum(
+                f.when(f.col(self.label_col) == L2GGoldStandard.GS_POSITIVE_LABEL, 1).otherwise(0)
+            ).alias("positives"),
+            f.countDistinct("studyLocusId").alias("loci"),
+        ).collect()[0]
+
+        # Dark matter counts: loci removed + matching positive rows (1 action)
+        dm_row = dark_matter_loci.join(
+            dark_matter_positives_per_locus, "studyLocusId"
+        ).agg(
+            f.count("*").alias("loci_removed"),
+            f.sum("dark_matter_count").alias("dm_positives"),
+        ).collect()[0]
 
         self._df = self._df.join(dark_matter_loci, "studyLocusId", "left_anti")
         dark_matter_loci.unpersist()
 
-        # --- Stats: after ---
-        rows_after = self._df.count()
-        positives_after = (
-            self._df.filter(
-                f.col(self.label_col) == L2GGoldStandard.GS_POSITIVE_LABEL
-            ).count()
-        )
-        loci_after = self._df.select("studyLocusId").distinct().count()
+        # Consolidate after-stats into a single aggregation (1 action)
+        after_row = self._df.agg(
+            f.count("*").alias("rows"),
+            f.sum(
+                f.when(f.col(self.label_col) == L2GGoldStandard.GS_POSITIVE_LABEL, 1).otherwise(0)
+            ).alias("positives"),
+            f.countDistinct("studyLocusId").alias("loci"),
+        ).collect()[0]
 
         def _pct_reduction(before: int, after: int) -> float:
             return round((before - after) / before * 100, 2) if before else 0.0
+
+        rows_before = int(before_row["rows"])
+        positives_before = int(before_row["positives"])
+        loci_before = int(before_row["loci"])
+        dark_matter_loci_count = int(dm_row["loci_removed"])
+        dark_matter_positives_count = int(dm_row["dm_positives"] or 0)
+        rows_after = int(after_row["rows"])
+        positives_after = int(after_row["positives"])
+        loci_after = int(after_row["loci"])
 
         stats: dict[str, Any] = {
             "before": {

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -470,8 +470,16 @@ class LocusToGeneStep:
 
         if self.filter_dark_matter:
             feature_matrix, dark_matter_stats = feature_matrix.filter_dark_matter_loci()
-            if self.model_path and dark_matter_stats:
-                self._write_dark_matter_stats(dark_matter_stats)
+            if dark_matter_stats:
+                if self.model_path:
+                    self._write_dark_matter_stats(dark_matter_stats)
+            else:
+                logging.warning(
+                    "filter_dark_matter=True but the filter had no effect: "
+                    "required signal or neighbourhood-distance features are "
+                    "absent from features_list. Verify that the dark matter "
+                    "features are included in the training feature set."
+                )
 
         # Run the training
         trained_model = LocusToGeneTrainer(
@@ -501,21 +509,11 @@ class LocusToGeneStep:
         Args:
             stats (dict[str, Any]): Stats dict returned by filter_dark_matter_loci.
         """
+        import fsspec
+
         log_path = f"{self.model_path}_dark_matter_stats.json"
-        payload = json.dumps(stats, indent=2)
-        if log_path.startswith("gs://"):
-            from urllib.parse import urlparse
-
-            from google.cloud import storage
-
-            parsed = urlparse(log_path)
-            bucket = storage.Client().bucket(parsed.hostname)
-            bucket.blob(parsed.path.lstrip("/")).upload_from_string(
-                payload, content_type="application/json"
-            )
-        else:
-            with open(log_path, "w") as fh:
-                fh.write(payload)
+        with fsspec.open(log_path, "w") as fh:
+            fh.write(json.dumps(stats, indent=2))
         logging.info("Dark matter filter stats written to %s", log_path)
 
     def _annotate_gold_standards_w_feature_matrix(self) -> L2GFeatureMatrix:

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -501,11 +501,21 @@ class LocusToGeneStep:
         Args:
             stats (dict[str, Any]): Stats dict returned by filter_dark_matter_loci.
         """
-        import fsspec
-
         log_path = f"{self.model_path}_dark_matter_stats.json"
-        with fsspec.open(log_path, "w") as fh:
-            json.dump(stats, fh, indent=2)
+        payload = json.dumps(stats, indent=2)
+        if log_path.startswith("gs://"):
+            from urllib.parse import urlparse
+
+            from google.cloud import storage
+
+            parsed = urlparse(log_path)
+            bucket = storage.Client().bucket(parsed.hostname)
+            bucket.blob(parsed.path.lstrip("/")).upload_from_string(
+                payload, content_type="application/json"
+            )
+        else:
+            with open(log_path, "w") as fh:
+                fh.write(payload)
         logging.info("Dark matter filter stats written to %s", log_path)
 
     def _annotate_gold_standards_w_feature_matrix(self) -> L2GFeatureMatrix:

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -185,6 +186,7 @@ class LocusToGeneStep:
         explain_predictions: bool = False,
         hf_credentials_path: str | None = None,
         wandb_credentials_path: str | None = None,
+        filter_dark_matter: bool = False,
     ) -> None:
         """Initialise the step and run the logic based on mode.
 
@@ -211,6 +213,7 @@ class LocusToGeneStep:
             explain_predictions (bool): Whether to extract SHAP importances for the L2G predictions. This is computationally expensive.
             hf_credentials_path (str | None): Optional path to the Hugging Face Hub credentials JSON file. If not provided, the HF_TOKEN environment variable will be used.
             wandb_credentials_path (str | None): Optional path to the Weights and Biases credentials JSON file. If not provided, the WANDB_API_KEY environment variable will be used.
+            filter_dark_matter (bool): Whether to remove loci where every gold-standard positive has no functional genomics signal (zero QTL colocalisation, E2G, and VEP below protein-altering threshold) and is not the nearest gene (all neighbourhood distance features < 1.0). Loci with at least one signal-carrying or nearest-gene positive are kept. Defaults to False.
 
         Raises:
             ValueError: If run_mode is not 'train' or 'predict'
@@ -273,6 +276,7 @@ class LocusToGeneStep:
         # Predict parameters
         self.l2g_threshold = l2g_threshold
         self.explain_predictions = explain_predictions
+        self.filter_dark_matter = filter_dark_matter
 
         # Load common inputs
         self.credible_set = StudyLocus.from_parquet(
@@ -464,6 +468,11 @@ class LocusToGeneStep:
         # Calculate the gold standard features
         feature_matrix = self._annotate_gold_standards_w_feature_matrix()
 
+        if self.filter_dark_matter:
+            feature_matrix, dark_matter_stats = feature_matrix.filter_dark_matter_loci()
+            if self.model_path and dark_matter_stats:
+                self._write_dark_matter_stats(dark_matter_stats)
+
         # Run the training
         trained_model = LocusToGeneTrainer(
             model=l2g_model, feature_matrix=feature_matrix
@@ -485,6 +494,19 @@ class LocusToGeneStep:
                     repo_id=self.hf_hub_repo_id,
                     commit_message=self.hf_model_commit_message,
                 )
+
+    def _write_dark_matter_stats(self, stats: dict[str, Any]) -> None:
+        """Write dark matter filtering stats as JSON next to the model path.
+
+        Args:
+            stats (dict[str, Any]): Stats dict returned by filter_dark_matter_loci.
+        """
+        import fsspec
+
+        log_path = f"{self.model_path}_dark_matter_stats.json"
+        with fsspec.open(log_path, "w") as fh:
+            json.dump(stats, fh, indent=2)
+        logging.info("Dark matter filter stats written to %s", log_path)
 
     def _annotate_gold_standards_w_feature_matrix(self) -> L2GFeatureMatrix:
         """Generate the feature matrix of annotated gold standards.

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -522,6 +522,9 @@ class LocusToGeneStep:
                 payload, content_type="application/json"
             )
         else:
+            from pathlib import Path
+
+            Path(log_path).parent.mkdir(parents=True, exist_ok=True)
             with open(log_path, "w") as fh:
                 fh.write(payload)
         logging.info("Dark matter filter stats written to %s", log_path)

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -509,11 +509,21 @@ class LocusToGeneStep:
         Args:
             stats (dict[str, Any]): Stats dict returned by filter_dark_matter_loci.
         """
-        import fsspec
+        from urllib.parse import urlparse
+
+        from google.cloud import storage
 
         log_path = f"{self.model_path}_dark_matter_stats.json"
-        with fsspec.open(log_path, "w") as fh:
-            fh.write(json.dumps(stats, indent=2))
+        payload = json.dumps(stats, indent=2)
+        if log_path.startswith("gs://"):
+            parsed = urlparse(log_path)
+            bucket = storage.Client().bucket(parsed.hostname)
+            bucket.blob(parsed.path.lstrip("/")).upload_from_string(
+                payload, content_type="application/json"
+            )
+        else:
+            with open(log_path, "w") as fh:
+                fh.write(payload)
         logging.info("Dark matter filter stats written to %s", log_path)
 
     def _annotate_gold_standards_w_feature_matrix(self) -> L2GFeatureMatrix:

--- a/tests/gentropy/dataset/test_l2g_feature_matrix.py
+++ b/tests/gentropy/dataset/test_l2g_feature_matrix.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pyspark.sql.functions as f
 import pytest
@@ -254,6 +254,103 @@ class TestFromFeaturesList:
             ),
             _schema=TargetIndex.get_schema(),
         )
+
+
+class TestFilterDarkMatterLoci:
+    """Tests for L2GFeatureMatrix.filter_dark_matter_loci."""
+
+    # Minimal schema: signal feature + nearest feature + gold standard label
+    _SCHEMA = (
+        "studyLocusId STRING, geneId STRING, goldStandardSet STRING, "
+        "eQtlColocClppMaximum FLOAT, distanceSentinelTssNeighbourhood FLOAT"
+    )
+
+    def _make_fm(self, spark: SparkSession, rows: list[Any]) -> L2GFeatureMatrix:
+        return L2GFeatureMatrix(
+            _df=spark.createDataFrame(rows, schema=self._SCHEMA),
+            with_gold_standard=True,
+        )
+
+    def test_all_dark_matter_locus_removed(self, spark: SparkSession) -> None:
+        """Locus where every positive is dark matter (no signal, not nearest) is dropped entirely."""
+        fm = self._make_fm(
+            spark,
+            [
+                # dark matter positive: no signal, not nearest
+                ("loc1", "gene1", "positive", 0.0, 0.5),
+                # negative in the same locus — should also be dropped
+                ("loc1", "gene2", "negative", 0.0, 1.0),
+                # clean locus — should be kept
+                ("loc2", "gene3", "positive", 0.9, 0.5),
+                ("loc2", "gene4", "negative", 0.0, 1.0),
+            ],
+        )
+        filtered, stats = fm.filter_dark_matter_loci()
+        remaining = {
+            r.studyLocusId for r in filtered._df.select("studyLocusId").collect()
+        }
+        assert "loc1" not in remaining
+        assert "loc2" in remaining
+        assert stats["dark_matter"]["study_locus_ids_removed"] == 1
+
+    def test_mixed_locus_kept(self, spark: SparkSession) -> None:
+        """Locus with one dark matter positive and one signal positive is kept."""
+        fm = self._make_fm(
+            spark,
+            [
+                ("loc1", "gene1", "positive", 0.0, 0.5),  # dark matter
+                ("loc1", "gene2", "positive", 0.8, 0.5),  # has signal → locus kept
+                ("loc1", "gene3", "negative", 0.0, 1.0),
+            ],
+        )
+        filtered, stats = fm.filter_dark_matter_loci()
+        remaining = {
+            r.studyLocusId for r in filtered._df.select("studyLocusId").collect()
+        }
+        assert "loc1" in remaining
+        assert stats["dark_matter"]["study_locus_ids_removed"] == 0
+
+    def test_nearest_gene_positive_protected(self, spark: SparkSession) -> None:
+        """Positive with no signal but nearest-gene status (neighbourhood = 1.0) is protected."""
+        fm = self._make_fm(
+            spark,
+            [
+                # nearest gene (neighbourhood = 1.0), no signal → NOT dark matter
+                ("loc1", "gene1", "positive", 0.0, 1.0),
+                ("loc1", "gene2", "negative", 0.0, 0.3),
+            ],
+        )
+        filtered, stats = fm.filter_dark_matter_loci()
+        remaining = {
+            r.studyLocusId for r in filtered._df.select("studyLocusId").collect()
+        }
+        assert "loc1" in remaining
+        assert stats["dark_matter"]["study_locus_ids_removed"] == 0
+
+    def test_no_nearest_features_is_noop(self, spark: SparkSession) -> None:
+        """When no neighbourhood distance features are present the filter is a no-op."""
+        fm = L2GFeatureMatrix(
+            _df=spark.createDataFrame(
+                [("loc1", "gene1", "positive", 0.0)],
+                "studyLocusId STRING, geneId STRING, goldStandardSet STRING, eQtlColocClppMaximum FLOAT",
+            ),
+            with_gold_standard=True,
+        )
+        filtered, stats = fm.filter_dark_matter_loci()
+        assert filtered._df.count() == 1
+        assert stats == {}
+
+    def test_raises_without_gold_standard(self, spark: SparkSession) -> None:
+        """Calling the filter on a matrix without gold standard labels raises ValueError."""
+        fm = L2GFeatureMatrix(
+            _df=spark.createDataFrame(
+                [("loc1", "gene1", 0.0)],
+                "studyLocusId STRING, geneId STRING, eQtlColocClppMaximum FLOAT",
+            ),
+            with_gold_standard=False,
+        )
+        with pytest.raises(ValueError, match="gold standard"):
+            fm.filter_dark_matter_loci()
 
 
 def test_fill_na(spark: SparkSession) -> None:

--- a/tests/gentropy/dataset/test_l2g_feature_matrix.py
+++ b/tests/gentropy/dataset/test_l2g_feature_matrix.py
@@ -266,6 +266,7 @@ class TestFilterDarkMatterLoci:
     )
 
     def _make_fm(self, spark: SparkSession, rows: list[Any]) -> L2GFeatureMatrix:
+        """Build a minimal gold-standard-annotated L2GFeatureMatrix from row tuples."""
         return L2GFeatureMatrix(
             _df=spark.createDataFrame(rows, schema=self._SCHEMA),
             with_gold_standard=True,
@@ -349,6 +350,28 @@ class TestFilterDarkMatterLoci:
                 ("loc1", "gene1", "positive", None, 0.5),
                 ("loc1", "gene2", "negative", None, 1.0),
             ],
+        )
+        filtered, stats = fm.filter_dark_matter_loci()
+        remaining = {
+            r.studyLocusId for r in filtered._df.select("studyLocusId").collect()
+        }
+        assert "loc1" not in remaining
+        assert stats["dark_matter"]["study_locus_ids_removed"] == 1
+
+    def test_null_vep_treated_as_no_signal(self, spark: SparkSession) -> None:
+        """NULL vepMaximum (absent VEP annotation) is coalesced to 0.0 and treated as below threshold."""
+        fm = L2GFeatureMatrix(
+            _df=spark.createDataFrame(
+                [
+                    # zero QTL signal, NULL vepMaximum, not nearest → dark matter
+                    ("loc1", "gene1", "positive", 0.0, 0.5, None),
+                    ("loc1", "gene2", "negative", 0.0, 1.0, None),
+                ],
+                "studyLocusId STRING, geneId STRING, goldStandardSet STRING, "
+                "eQtlColocClppMaximum FLOAT, distanceSentinelTssNeighbourhood FLOAT, "
+                "vepMaximum FLOAT",
+            ),
+            with_gold_standard=True,
         )
         filtered, stats = fm.filter_dark_matter_loci()
         remaining = {

--- a/tests/gentropy/dataset/test_l2g_feature_matrix.py
+++ b/tests/gentropy/dataset/test_l2g_feature_matrix.py
@@ -340,6 +340,23 @@ class TestFilterDarkMatterLoci:
         assert filtered._df.count() == 1
         assert stats == {}
 
+    def test_null_signal_treated_as_no_signal(self, spark: SparkSession) -> None:
+        """NULL signal features (from missing coloc/VEP inner joins) are treated as zero."""
+        fm = self._make_fm(
+            spark,
+            [
+                # NULL signal (inner join produced no row) + not nearest → dark matter
+                ("loc1", "gene1", "positive", None, 0.5),
+                ("loc1", "gene2", "negative", None, 1.0),
+            ],
+        )
+        filtered, stats = fm.filter_dark_matter_loci()
+        remaining = {
+            r.studyLocusId for r in filtered._df.select("studyLocusId").collect()
+        }
+        assert "loc1" not in remaining
+        assert stats["dark_matter"]["study_locus_ids_removed"] == 1
+
     def test_raises_without_gold_standard(self, spark: SparkSession) -> None:
         """Calling the filter on a matrix without gold standard labels raises ValueError."""
         fm = L2GFeatureMatrix(


### PR DESCRIPTION
## Background

Analysis of the 26.03 L2G training set revealed a structural problem: gold-standard positives with no functional genomics signal — termed **dark matter** — cannot be learned from by the model. The model sees no QTL colocalisation, no E2G signal, no coding variant, only distance features that are present for every gene in the locus. Retaining them adds noise without providing any learnable pattern.

## Definition of dark matter

A positive is dark matter when **both** of the following hold simultaneously:

**1. No functional genomics signal** — all of these are zero or absent (NULL treated as zero):
- `eQtlColocClppMaximum`, `eQtlColocH4Maximum`
- `pQtlColocClppMaximum`, `pQtlColocH4Maximum`
- `sQtlColocClppMaximum`, `sQtlColocH4Maximum`
- `transPQtlColocH4Maximum`
- `e2gMean`
- `vepMaximum` < 0.6 (below protein-altering variant threshold, SO:0001818)

NULL values are treated as zero because colocalisation and VEP features are produced via inner joins — a missing row means no evidence, not unknown evidence.

**2. Not the nearest gene** — all neighbourhood distance features < 1.0:
- `distanceSentinelFootprintNeighbourhood`
- `distanceFootprintMeanNeighbourhood`
- `distanceTssMeanNeighbourhood`
- `distanceSentinelTssNeighbourhood`

A value of 1.0 in any neighbourhood distance feature means the gene is the nearest in the locus window. Nearest-gene positives are kept even without functional signal, because proximity-based learning is still valid for them.

## Locus removal logic

A `studyLocusId` is removed only when **all** of its positives are dark matter. If a locus has two positives and one has signal, the whole locus is kept. When a locus is removed, all rows (positives and negatives) are dropped to preserve class balance within retained loci.

## What was changed

### `L2GFeatureMatrix.filter_dark_matter_loci()` (new method)
- Builds the no-signal condition from `_DARK_MATTER_SIGNAL_FEATURES` (8 QTL/E2G features) + VEP threshold check; all comparisons coalesce NULL to 0.0 so that inner-join-absent evidence is correctly treated as no signal
- Builds the not-nearest condition from `_DARK_MATTER_NEAREST_FEATURES` (4 distance neighbourhood features)
- Returns early (no-op + warning) if the required signal or distance features are absent from the matrix
- Counts all positives per locus and dark matter positives per locus; marks a locus for removal only when the two counts are equal (all positives are dark matter)
- Removes all rows for dark matter loci via `left_anti` join; persists the filtered matrix so downstream training does not recompute it
- Returns `(filtered_matrix, stats_dict)` with before/after row counts, positive counts, studyLocusId counts, and % reductions

### `LocusToGeneStep`
- New parameter `filter_dark_matter: bool = False` (opt-in, no change to default behaviour)
- When enabled, calls `filter_dark_matter_loci()` after gold standard annotation and before model fitting
- Logs a warning if the filter has no effect (required features absent from `features_list`)
- Writes a JSON stats file to `{model_path}_dark_matter_stats.json`; creates the parent directory if needed for local paths

### `LocusToGeneConfig`
- Adds `filter_dark_matter: bool = False` — enable via Hydra override `step.filter_dark_matter=true`

## Stats file format

```json
{
  "before":        { "rows": 200536, "positives": 13060, "study_locus_ids": 8412 },
  "dark_matter":   { "positive_rows": 2928,  "study_locus_ids_removed": 2639 },
  "after":         { "rows": 152687, "positives": 10132, "study_locus_ids": 5773 },
  "pct_reduction": { "rows": 23.9,   "positives": 22.4,  "study_locus_ids": 31.4 }
}
```

## How to enable

```yaml
# Hydra config
step:
  filter_dark_matter: true
```

or CLI:
```bash
python -m gentropy step=locus_to_gene step.filter_dark_matter=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)