### PR TITLE
fix: handle OmegaConf DictConfig in Session connectors

### DIFF
--- a/src/gentropy/common/session.py
+++ b/src/gentropy/common/session.py
@@ -176,6 +176,10 @@ class Session:
         for bucket-level operations or as a requester-pays billing project fallback.
         See :class:`~gentropy.external.gcs.GCSConfig` for the full set of options.
 
+        To allow running locally with GCS credentials, one can set the ``auth_type``
+        to ``APPLICATION_DEFAULT`` and ensure that ``gcloud auth application-default login``
+        has been run to populate the local ADC credentials file.
+
         >>> session = Session(
         ...     add_gcs_connector=True,
         ...     gcs_configuration={'project_id': 'my-gcp-project'},
@@ -225,8 +229,8 @@ class Session:
         log_level: str | None = "INFO",
         add_s3_connector: bool = False,
         add_gcs_connector: bool = False,
-        s3_configuration: dict[str, str] | None = None,
-        gcs_configuration: dict[str, str] | None = None,
+        s3_configuration: dict[str, Any] | None = None,
+        gcs_configuration: dict[str, Any] | None = None,
         s3_configuration_path: str | None = None,
         gcs_configuration_path: str | None = None,
     ) -> None:
@@ -258,9 +262,9 @@ class Session:
                 If specified as `true`, the session will request the GCS connector and attempt to resolve
                 necessary credentials (see `gentropy.external.gcs.GCSConfig`) from the provided `gcs_configuration` parameter, `gcs_configuration_path` or environment variables
                 in that order of precedence. If no credentials are provided, the failure is raised.
-            s3_configuration (dict[str, str] | None): Optional dictionary with s3 configuration parameters to include in the session. Defaults to None.
+            s3_configuration (dict[str, Any] | None): Optional dictionary with s3 configuration parameters to include in the session. Defaults to None.
                 The object needs to follow the `gentropy.external.s3.S3Config` class.
-            gcs_configuration (dict[str, str] | None): Optional dictionary with GCS configuration parameters to include in the session. Defaults to None.
+            gcs_configuration (dict[str, Any] | None): Optional dictionary with GCS configuration parameters to include in the session. Defaults to None.
                 The object needs to follow the `gentropy.external.gcs.GCSConfig` class.
             s3_configuration_path (str | None): Optional path to a JSON file with S3 configuration parameters. Defaults to None. If file is provided,
                 it will need to live in `shared` folder that is accessible by the Spark cluster (not in the distributed file system.)
@@ -557,13 +561,13 @@ class Session:
         ).set("spark.gentropy.useEnhancedBgzipCodec", "true")
 
     def _setup_s3_connector(
-        self, c: SparkConf, s3_configuration: dict[str, str] | str | None = None
+        self, c: SparkConf, s3_configuration: dict[str, Any] | str | None = None
     ) -> SparkConf:
         """Setup Spark configuration for S3 compatible storage.
 
         Args:
             c (SparkConf): Existing Spark configuration.
-            s3_configuration (dict[str, str] | str | None): Dictionary with s3 configuration or path to json containing
+            s3_configuration (dict[str, Any] | str | None): Dictionary with s3 configuration or path to json containing
                  parameters to include in the session or path to configuration file.
 
         Returns:
@@ -577,6 +581,9 @@ class Session:
 
         """
         from gentropy.external.s3 import S3Config
+
+        if s3_configuration is not None and not isinstance(s3_configuration, (dict, str)):
+            s3_configuration = dict(s3_configuration)
 
         match s3_configuration:
             case dict():
@@ -602,13 +609,15 @@ class Session:
         return c
 
     def _setup_gcs_connector(
-        self, c: SparkConf, gcs_configuration: dict[str, str] | str | None = None
+        self,
+        c: SparkConf,
+        gcs_configuration: dict[str, Any] | str | None = None,
     ) -> SparkConf:
         """Setup Spark configuration for GCS compatible storage.
 
         Args:
             c (SparkConf): Existing Spark configuration.
-            gcs_configuration (dict[str, str] | str | None): Dictionary with GCS configuration parameters to include in the session or path to json containing
+            gcs_configuration (dict[str, Any] | str | None): Dictionary with GCS configuration parameters to include in the session or path to json containing
                  parameters to include in the session or path to configuration file.
 
         Returns:
@@ -621,6 +630,10 @@ class Session:
             3. Environment variables (see `GCSConfig.from_env` for more details)
         """
         from gentropy.external.gcs import GCSConfig
+
+        # Hydra passes DictConfig (OmegaConf) objects which don't inherit from dict
+        if gcs_configuration is not None and not isinstance(gcs_configuration, (dict, str)):
+            gcs_configuration = dict(gcs_configuration)
 
         match gcs_configuration:
             case dict():
@@ -661,7 +674,7 @@ class Session:
 
         for key, value in options.items():
             c = c.set(key, value)
-        c = self._append_package(c, GCSConfig._HADOOP_CONNECTOR_PKG)
+        c = self._append_jar(c, GCSConfig._HADOOP_CONNECTOR_JAR)
         self._gcs_configuration = dict(conf)
         return c
 
@@ -699,6 +712,27 @@ class Session:
                 f"{existing_packages},{package}" if existing_packages else package
             )
             return c.set("spark.jars.packages", new_packages)
+        return c
+
+    @staticmethod
+    def _append_repository(c: SparkConf, repository: str) -> SparkConf:
+        """Append a Maven repository URL to the existing spark.jars.repositories configuration.
+
+        Ivy consults these repositories in addition to Maven Central when resolving
+        packages declared via ``spark.jars.packages``.
+
+        Args:
+            c (SparkConf): Existing Spark configuration.
+            repository (str): Maven repository URL to add (e.g. ``https://maven.google.com``).
+
+        Returns:
+            SparkConf: Adjusted spark configuration with the repository appended to
+                ``spark.jars.repositories``.
+        """
+        existing = c.get("spark.jars.repositories", "")
+        if repository not in existing:
+            new_repos = f"{existing},{repository}" if existing else repository
+            return c.set("spark.jars.repositories", new_repos)
         return c
 
     @staticmethod
@@ -894,6 +928,44 @@ class Session:
                 samplingRatio=kwargs.get("samplingRation", 0.4),
             )
         return self.spark.createDataFrame(data=df, schema=schema, verifySchema=True)
+
+    def list_hadoop_paths(self, path: str) -> list[str]:
+        """List files matching a Hadoop-compatible filesystem path or glob pattern.
+
+        Delegates to Hadoop's ``FileSystem.globStatus``, which resolves the correct
+        connector (GCS, S3A, HDFS, local…) from the URI scheme using auth already
+        configured in the SparkContext. This is a driver-side metadata call — no data
+        is read from the files themselves.
+
+        Args:
+            path (str): Hadoop path, optionally with glob wildcards
+                (e.g. ``gs://bucket/prefix/*.tsv.gz``).
+
+        Returns:
+            list[str]: Sorted list of matching file path strings.
+                Empty list when no files match the pattern.
+
+        Examples:
+            List all parquet files under a GCS prefix:
+
+            >>> session.list_hadoop_paths("gs://bucket/data/*.parquet") # doctest: +SKIP
+            ['gs://bucket/data/part-00000.parquet', 'gs://bucket/data/part-00001.parquet']
+
+            Returns an empty list when nothing matches:
+
+            >>> session.list_hadoop_paths("gs://bucket/nonexistent/*.tsv.gz") # doctest: +SKIP
+            []
+        """
+        sc = self.spark.sparkContext
+        # NOTE: The code below uses the PySpark JVM hadoop FileSystem to list objects
+        # This is not the most elegant way of listing, but does not bound us to any
+        # specific library to list objects through the object storage, rather
+        # uses direct Hadoop FileSystem API which should work as long as the connector is properly configured in the session.
+        jpath = sc._jvm.org.apache.hadoop.fs.Path(path)
+        conf = sc._jsc.hadoopConfiguration()
+        fs = sc._jvm.org.apache.hadoop.fs.FileSystem.get(jpath.toUri(), conf)
+        statuses = fs.globStatus(jpath)
+        return [] if statuses is None else sorted(str(s.getPath()) for s in statuses)
 
 
 class JavaLogger(Protocol):

--- a/src/gentropy/external/gcs/__init__.py
+++ b/src/gentropy/external/gcs/__init__.py
@@ -84,11 +84,14 @@ class GCSConfig(ExternalConfig):
     ['paid-bucket-1', 'paid-bucket-2']
     """
 
-    _HADOOP_CONNECTOR_PKG: ClassVar[str] = (
-        "com.google.cloud.bigdataoss:gcs-connector:4.0.4"
+    _HADOOP_CONNECTOR_JAR: ClassVar[str] = (
+        "https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/download/v3.1.17/gcs-connector-3.1.17-shaded.jar"
     )
     """Connector for Google Cloud Storage.
-        See https://mvnrepository.com/artifact/com.google.cloud.bigdataoss/gcs-connector/4.0.4"""
+        See https://github.com/GoogleCloudDataproc/hadoop-connectors/releases and
+        https://docs.cloud.google.com/managed-spark/docs/concepts/connectors/cloud-storage#connector-setup-on-non-dataproc-clusters
+        Note that the shaded version is recommended to avoid dependency conflicts.
+    """
 
     project_id: str | None = None
     """Google Cloud Project ID. Required only for list-buckets and create-bucket operations,
@@ -162,11 +165,13 @@ class GCSConfig(ExternalConfig):
         buckets_raw = os.getenv("GCS_REQUESTER_PAYS_BUCKETS")
         return cls(
             project_id=os.getenv("GCS_PROJECT_ID"),
-            auth_type=os.getenv("GCS_AUTH_TYPE", GCSAuthType.COMPUTE_ENGINE),
+            auth_type=GCSAuthType(
+                os.getenv("GCS_AUTH_TYPE", GCSAuthType.COMPUTE_ENGINE.value)
+            ),
             keyfile_path=os.getenv("GCS_KEYFILE_PATH"),
             impersonation_sa=os.getenv("GCS_IMPERSONATION_SA"),
-            requester_pays=os.getenv(
-                "GCS_REQUESTER_PAYS", GCSRequesterPaysMode.DISABLED
+            requester_pays=GCSRequesterPaysMode(
+                os.getenv("GCS_REQUESTER_PAYS", GCSRequesterPaysMode.DISABLED.value)
             ),
             requester_pays_project_id=os.getenv("GCS_REQUESTER_PAYS_PROJECT_ID"),
             requester_pays_buckets=buckets_raw.split(",") if buckets_raw else None,

--- a/tests/gentropy/common/test_session.py
+++ b/tests/gentropy/common/test_session.py
@@ -17,6 +17,30 @@ if TYPE_CHECKING:
     from typing import Any
 
 
+def test_list_hadoop_paths(session: Session, tmp_path: Path) -> None:
+    """Test Session.list_hadoop_paths with the local Hadoop filesystem.
+
+    Uses tmp_path (local files) so no GCS/S3/HDFS connection is needed —
+    Hadoop's LocalFileSystem handles file:// paths identically to remote schemes.
+    """
+    (tmp_path / "a.tsv").write_text("col\nval\n")
+    (tmp_path / "b.tsv").write_text("col\nval\n")
+    (tmp_path / "c.parquet").write_bytes(b"PAR1")  # must not appear in *.tsv results
+
+    matched = session.list_hadoop_paths((tmp_path / "*.tsv").as_posix())
+
+    # Hadoop returns fully-qualified file:// URIs; compare by filename only
+    assert len(matched) == 2
+    assert {p.rsplit("/", 1)[-1] for p in matched} == {"a.tsv", "b.tsv"}
+    assert all(p.endswith(".tsv") for p in matched)
+    assert matched == sorted(matched)  # result must be sorted
+
+
+def test_list_hadoop_paths_empty(session: Session, tmp_path: Path) -> None:
+    """Test that list_hadoop_paths returns an empty list when no files match."""
+    assert session.list_hadoop_paths((tmp_path / "*.nonexistent").as_posix()) == []
+
+
 def test_log4j_creation(spark: SparkSession) -> None:
     """Test session log4j."""
     assert isinstance(Log4j(spark=spark), Log4j)

--- a/tests/gentropy/no_spark/test_session_configuration.py
+++ b/tests/gentropy/no_spark/test_session_configuration.py
@@ -202,7 +202,7 @@ class TestGCSConnectorConfiguration:
         assert conf.get("spark.hadoop.fs.gs.status.parallel.enable") == "true"
         assert conf.get("spark.hadoop.fs.gs.copy.with.rewrite.enable") == "true"
         assert conf.get("spark.hadoop.fs.gs.glob.algorithm") == "CONCURRENT"
-        assert GCSConfig._HADOOP_CONNECTOR_PKG in conf.get("spark.jars.packages", "")
+        assert GCSConfig._HADOOP_CONNECTOR_JAR in conf.get("spark.jars", "")
 
     @pytest.mark.usefixtures("_no_spark_session")
     def test_gcs_service_account_keyfile_connector(self) -> None:
@@ -241,4 +241,4 @@ class TestGCSConnectorConfiguration:
             conf.get("spark.hadoop.fs.gs.requester.pays.project.id")
             == "billing-project"
         )
-        assert GCSConfig._HADOOP_CONNECTOR_PKG in conf.get("spark.jars.packages", "")
+        assert GCSConfig._HADOOP_CONNECTOR_JAR in conf.get("spark.jars", "")


### PR DESCRIPTION
## ✨ Context

This is the part of the larger refactor of Finngen Meta Analysis & DeCODE harmonisation efforts. The overarching goal is to unify the harmonisation pipelines and include the 2-way meta analysis (subsequent PRs).

For deCODE genetics harmonisation source is s3 compatible storage
For finngen-meta the harmonisation source is their GCS bucket

This PR adds the `list_hadoop_paths` method, that uses pure Hadoop java connector from python to list files. This is crucial, so we do not need to include or keep vendor specific packages like (google cloud storage or boto3) to the dependency stack. This method is used to list the existing summary statistics files in all harmonisation pipelines that are part of this larger effort. 

Also testing the addition of hadoop-connector jars to the gentropy I have found issues with connector for GCS, that is too lightweight and does not ship with all requrired packages, it is changed, so we can use the shaded jar with all dependencies included. See links in the code for more details. 


<!---
Congratulations! You've made it this far!
Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your contribution.
What's the context for the changes? If the changes are related to a specific issue, please [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to it:
-->

## 🛠 What does this PR implement

- Coerce OmegaConf DictConfig to plain dict before passing to S3Config/GCSConfig so Hydra-managed configs work end-to-end without manual conversion
- Switch GCS connector from Maven package resolution (gcs-connector:4.0.4 via spark.jars.packages) to a direct shaded JAR URL (v3.1.17) to eliminate Ivy dependency conflicts at runtime
- Add _append_repository() static helper to Session for future Maven repo wiring
- Add list_hadoop_paths() to Session for driver-side glob listing over any Hadoop-compatible filesystem (GCS, S3A, local) using the already-configured connector
- Fix GCSConfig.from_env() to explicitly cast env var strings through GCSAuthType and GCSRequesterPaysMode enums rather than passing raw strings
- Widen s3_configuration / gcs_configuration type hints from dict[str, str] to dict[str, Any] to allow nested config values
- Add tests for list_hadoop_paths() using local tmp_path filesystem


<!--- _Detailed description of the changes introduced, Give examples of the changes you've made in this pull request, include an itemized list if you can and
add diagrams or images if necessary. It'll help the reviewer_ -->

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [ ] Do these changes cover one single feature (one change at a time)?
- [ ] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [ ] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ ] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `uv run pre-commit run --all-files`)?
