### PR TITLE
feat(ccs): add case control study validation

### DIFF
--- a/src/gentropy/dataset/study_index.py
+++ b/src/gentropy/dataset/study_index.py
@@ -58,6 +58,12 @@ class StudyQualityCheck(Enum):
         SMALL_NUMBER_OF_SNPS (str): Flagging if the number of SNPs in the study is below the expected threshold.
         CASE_CASE_STUDY_DESIGN (str): Flagging if the study design is case-case.
         DEPRECATED_PROJECT (str): Flagging if the projectId is deprecated.
+        INVALID_SAMPLE_SIZE (str): Flagging if the sample size is null or equal to zero.
+        CASE_CONTROL_STUDY_DESIGN (str): Flagging if the study has non empty or zero nCases, nControls & nSamples with matching sum.
+        CASE_CONTROL_SUM_NEQ_SAMPLE_SIZE (str): Flagging if the study has non empty or zero nCases, nControls & nSamples with non matching sum.
+        ONE_ONLY_CASE_OR_CONTROL (str): Flagging if the study has only cases or only controls.
+        MEASUREMENT_STUDY_DESIGN (str): Flagging if the study has non empty or zero nSamples with empty nCases and nControls.
+
     """
 
     UNRESOLVED_TARGET = "Target/gene identifier could not match to reference"
@@ -77,6 +83,31 @@ class StudyQualityCheck(Enum):
     )
     CASE_CASE_STUDY_DESIGN = "Case-case study design"
     DEPRECATED_PROJECT = "Deprecated project"
+    INVALID_SAMPLE_SIZE = "Sample size is null or equal to zero"
+    CASE_CONTROL_STUDY_DESIGN = (
+        "Study has non empty or zero nCases, nControls & nSamples with matching sum"
+    )
+    CASE_CONTROL_SUM_NEQ_SAMPLE_SIZE = (
+        "Study has non empty or zero nCases, nControls & nSamples with non matching sum"
+    )
+    ONE_ONLY_CASE_OR_CONTROL = "Study has only cases or only controls"
+    MEASUREMENT_STUDY_DESIGN = (
+        "Study has non empty or zero nSamples with empty nCases and nControls"
+    )
+
+
+class StudyType(Enum):
+    """Enum type hosting the expected study types."""
+
+    GWAS = "gwas"
+    EQTL = "eqtl"
+    PQTL = "pqtl"
+    SQTL = "sqtl"
+    TUQTL = "tuqtl"
+    SCEQTL = "sceqtl"
+    SCPQTL = "scpqtl"
+    SCSQTL = "scsqtl"
+    SCTUQTL = "sctuqtl"
 
 
 @dataclass
@@ -86,17 +117,7 @@ class StudyIndex(Dataset):
     A study index dataset captures all the metadata for all studies including GWAS and Molecular QTL.
     """
 
-    VALID_TYPES = [
-        "gwas",
-        "eqtl",
-        "pqtl",
-        "sqtl",
-        "tuqtl",
-        "sceqtl",
-        "scpqtl",
-        "scsqtl",
-        "sctuqtl",
-    ]
+    VALID_TYPES = [s.value for s in StudyType]
 
     @staticmethod
     def _aggregate_samples_by_ancestry(merged: Column, ancestry: Column) -> Column:
@@ -594,6 +615,73 @@ class StudyIndex(Dataset):
                 ),
             )
             .drop("isIdFound")
+        )
+
+        return StudyIndex(_df=validated_df, _schema=StudyIndex.get_schema())
+
+    @qc_test
+    def validate_ccs(self: StudyIndex) -> StudyIndex:
+        """Validate nCases, nControls & nSamples.
+
+        Returns:
+            StudyIndex: where studies are flagged if nCases, nControls & nSamples are not consistent with each other.
+        """
+        cases_above_zero = (f.col("nCases") > 0) & (f.col("nCases").isNotNull())
+        cases_null_or_zero = (f.col("nCases").isNull()) | (f.col("nCases") == 0)
+        ctrls_above_zero = (f.col("nControls") > 0) & (f.col("nControls").isNotNull())
+        ctrls_null_or_zero = (f.col("nControls").isNull()) | (f.col("nControls") == 0)
+        samples_above_zero = (f.col("nSamples") > 0) & (f.col("nSamples").isNotNull())
+        samples_null_or_zero = (f.col("nSamples").isNull()) | (f.col("nSamples") == 0)
+        sum_match = f.col("nCases") + f.col("nControls") == f.col("nSamples")
+
+        # Complex conditions
+        cc_eq_n = cases_above_zero & ctrls_above_zero & samples_above_zero & sum_match
+        cc_neq_n = cases_above_zero & ctrls_above_zero & samples_above_zero & ~sum_match
+        empty_cc_and_n = cases_null_or_zero & ctrls_null_or_zero & samples_above_zero
+        non_empty_cases = cases_above_zero & ctrls_null_or_zero & samples_above_zero
+        non_empty_ctrls = cases_null_or_zero & ctrls_above_zero & samples_above_zero
+
+        validated_df = (
+            self.df.withColumn(
+                "qualityControls",
+                StudyIndex.update_quality_flag(
+                    f.col("qualityControls"),
+                    cc_eq_n,
+                    StudyQualityCheck.CASE_CONTROL_STUDY_DESIGN,
+                ),
+            )
+            .withColumn(
+                "qualityControls",
+                StudyIndex.update_quality_flag(
+                    f.col("qualityControls"),
+                    empty_cc_and_n,
+                    StudyQualityCheck.MEASUREMENT_STUDY_DESIGN,
+                ),
+            )
+            .withColumn(
+                "qualityControls",
+                StudyIndex.update_quality_flag(
+                    f.col("qualityControls"),
+                    samples_null_or_zero,
+                    StudyQualityCheck.INVALID_SAMPLE_SIZE,
+                ),
+            )
+            .withColumn(
+                "qualityControls",
+                StudyIndex.update_quality_flag(
+                    f.col("qualityControls"),
+                    cc_neq_n,
+                    StudyQualityCheck.CASE_CONTROL_SUM_NEQ_SAMPLE_SIZE,
+                ),
+            )
+            .withColumn(
+                "qualityControls",
+                StudyIndex.update_quality_flag(
+                    f.col("qualityControls"),
+                    non_empty_cases | non_empty_ctrls,
+                    StudyQualityCheck.ONE_ONLY_CASE_OR_CONTROL,
+                ),
+            )
         )
 
         return StudyIndex(_df=validated_df, _schema=StudyIndex.get_schema())

--- a/src/gentropy/study_validation.py
+++ b/src/gentropy/study_validation.py
@@ -80,13 +80,16 @@ class StudyValidationStep:
             .validate_disease(disease_index)  # Flagging invalid EFOs
             .validate_biosample(biosample_index)  # Flagging invalid biosample in QTLs
             .validate_analysis_flags()  # Flagging studies with case case design
+            .validate_ccs()  # Flagging case-control-sample mismatches
         )
 
         if heritability_input_path is not None:
             heritability_df = session.spark.read.parquet(heritability_input_path)
             validated = validated.collect_heritability(heritability_df)
 
-        study_index_with_qc = validated.persist()  # we will need this for 2 types of outputs
+        study_index_with_qc = (
+            validated.persist()
+        )  # we will need this for 2 types of outputs
 
         result = study_index_with_qc.valid_rows(invalid_qc_reasons)
         (

--- a/tests/gentropy/dataset/test_study_index.py
+++ b/tests/gentropy/dataset/test_study_index.py
@@ -847,3 +847,113 @@ class TestProjectIdValidation:
             .collect()
             == expected_data
         ), "Should have expected qualityControls"
+
+
+class TestValidateCaseControlSampleSize:
+    """Test StudyIndex.validate_ccs.
+
+    Every non-synthetic case below uses a real studyId and its real
+    nCases/nControls/nSamples values, pulled live from the Open Targets study
+    table (release 26.03)  to confirm validate_ccs
+    classifies actual production data as expected. Counts for the full table
+    (2,016,409 studies, exhaustive over the 5 categories, no residual):
+      CASE_CONTROL_STUDY_DESIGN:        27,413
+      MEASUREMENT_STUDY_DESIGN:      1,987,211
+      ONE_ONLY_CASE_OR_CONTROL:            781
+      INVALID_SAMPLE_SIZE:                  605
+      CASE_CONTROL_SUM_NEQ_SAMPLE_SIZE:     399 (mostly off-by-1 rounding;
+        a handful of very large mismatches up to ~2.8M, where nSamples
+        reflects a bigger meta-analysis cohort than the reported cases/controls)
+    No negative nCases/nControls/nSamples were found anywhere in the table.
+    """
+
+    STUDY_REQUIRED_SCHEMA = (
+        "studyId STRING, projectId STRING, studyType STRING, "
+        "nCases INT, nControls INT, nSamples INT, qualityControls ARRAY<STRING>"
+    )
+
+    @pytest.mark.parametrize(
+        ["study_id", "n_cases", "n_controls", "n_samples", "expected_flags"],
+        [
+            pytest.param(
+                "FINNGEN_R12_AUTOIMMUNE_HYPERTHYROIDISM",
+                2469,
+                370637,
+                373106,
+                [StudyQualityCheck.CASE_CONTROL_STUDY_DESIGN.value],
+                id="clean case-control study, sum matches nSamples",
+            ),
+            pytest.param(
+                "UKB_PPP_EUR_CEP20_Q96NB1_OID21209_v1",
+                None,
+                None,
+                32907,
+                [StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value],
+                id="pQTL study, no cases or controls",
+            ),
+            pytest.param(
+                "GCST90091650",
+                0,
+                0,
+                None,
+                [StudyQualityCheck.INVALID_SAMPLE_SIZE.value],
+                id="nSamples null, cases/controls explicitly zero",
+            ),
+            pytest.param(
+                "GCST002406",
+                9978,
+                0,
+                9978,
+                [StudyQualityCheck.ONE_ONLY_CASE_OR_CONTROL.value],
+                id="case-only study, nCases == nSamples and nControls == 0",
+            ),
+            pytest.param(
+                "GCST000062",
+                None,
+                2431,
+                3362,
+                [StudyQualityCheck.ONE_ONLY_CASE_OR_CONTROL.value],
+                id="control-only study, nSamples exceeds nControls with nCases null",
+            ),
+            pytest.param(
+                "GCST002914",
+                62,
+                84,
+                147,
+                [StudyQualityCheck.CASE_CONTROL_SUM_NEQ_SAMPLE_SIZE.value],
+                id="sum off by exactly 1 from nSamples (rounding artifact)",
+            ),
+            pytest.param(
+                "GCST90627776",
+                102130,
+                14013085,
+                16938258,
+                [StudyQualityCheck.CASE_CONTROL_SUM_NEQ_SAMPLE_SIZE.value],
+                id="sum ~2.8M below nSamples (subset of a larger meta-analysis cohort)",
+            ),
+        ],
+    )
+    def test_validate_ccs(
+        self: TestValidateCaseControlSampleSize,
+        spark: SparkSession,
+        study_id: str,
+        n_cases: int | None,
+        n_controls: int | None,
+        n_samples: int | None,
+        expected_flags: list[str],
+    ) -> None:
+        """Test that validate_ccs assigns exactly the expected QC flag(s) per study design."""
+        si = StudyIndex(
+            _df=spark.createDataFrame(
+                [(study_id, "GCST", "gwas", n_cases, n_controls, n_samples, [])],
+                self.STUDY_REQUIRED_SCHEMA,
+            )
+        )
+        validated_si = si.validate_ccs()
+        assert isinstance(validated_si, StudyIndex), "should be a StudyIndex"
+        observed_flags = (
+            validated_si.df.filter(f.col("studyId") == study_id)
+            .select("qualityControls")
+            .collect()[0]["qualityControls"]
+        )
+        assert sorted(observed_flags) == sorted(expected_flags)

--- a/tests/gentropy/step/test_study_qc.py
+++ b/tests/gentropy/step/test_study_qc.py
@@ -59,6 +59,7 @@ class TestStudyQcStep:
         study_index.validate_disease = MagicMock(return_value=study_index)
         study_index.validate_biosample = MagicMock(return_value=study_index)
         study_index.validate_analysis_flags = MagicMock(return_value=study_index)
+        study_index.validate_ccs = MagicMock(return_value=study_index)
         study_index.persist = MagicMock(return_value=study_index)
         study_index.valid_rows = MagicMock(return_value=study_index)
 
@@ -96,6 +97,7 @@ class TestStudyQcStep:
         study_index.validate_disease.assert_called_once()
         study_index.validate_biosample.assert_called_once()
         study_index.validate_analysis_flags.assert_called_once()
+        study_index.validate_ccs.assert_called_once()
 
         # Assert valid_rows
         study_index.valid_rows.assert_any_call(invalid_qc_reasons)


### PR DESCRIPTION
---
✨ Context

Study QC currently has no check for internal consistency between nCases, nControls, and nSamples, allowing studies with mismatched or missing sample-size fields to pass validation silently.

🛠 What does this PR implement

- Adds a new validate_ccs QC method to StudyIndex that flags studies where nCases, nControls, and nSamples are inconsistent:
  - INVALID_SAMPLE_SIZE: nSamples is null or zero.
  - CASE_CONTROL_STUDY_DESIGN: nCases + nControls == nSamples (valid case-control design).
  - CASE_CONTROL_SUM_NEQ_SAMPLE_SIZE: nCases + nControls != nSamples.
  - ONE_ONLY_CASE_OR_CONTROL: only one of nCases/nControls is populated.
  - MEASUREMENT_STUDY_DESIGN: nSamples populated but both nCases and nControls are empty (e.g. quantitative trait studies).
- Introduces a StudyType enum for the study type strings (gwas, eqtl, pqtl, etc.), replacing the hardcoded VALID_TYPES list on StudyIndex with [s.value for s in StudyType].
- Wires validate_ccs() into the StudyValidationStep QC pipeline.


🚦 Before submitting

- [x] Do these changes cover one single feature (one change at a time)?
- [x] Did you read the contributor guideline?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you make sure there is no commented out code in this PR?
- [x] Did you follow conventional commits standards in PR title and commit messages?
- [x] Did you make sure the branch is up-to-date with the dev branch?
- [x] Did you write any new necessary tests?
- [x] Did you make sure the changes pass local tests (make test)?
- [x] Did you make sure the changes pass pre-commit rules (e.g uv run pre-commit run --all-files)?
