### PR TITLE
feat(qc): relax sumstats QC thresholds for exome/wgs-gwas studies

### DIFF
--- a/src/gentropy/dataset/study_index.py
+++ b/src/gentropy/dataset/study_index.py
@@ -696,8 +696,16 @@ class StudyIndex(Dataset):
         threshold_min_gc_lambda: float = 0.7,
         threshold_max_gc_lambda: float = 2.5,
         threshold_min_n_variants: int = 2_000_000,
+        seq_threshold_mean_beta: float = 1.0,
+        seq_threshold_min_gc_lambda: float = 0.1,
+        seq_threshold_max_gc_lambda: float = 2.5,
+        seq_threshold_min_n_variants: int = 1_000_000,
     ) -> StudyIndex:
         """Annotate summary stats QC information.
+
+        For studies whose ``analysisFlags`` contain ``ExWAS`` or ``wgsGWAS``, relaxed
+        thresholds are applied because the genetic data source is exome or whole genome
+        sequencing. The PZ check (mean/se diff PZ) is skipped for these studies.
 
         Args:
             sumstats_qc (SummaryStatisticsQC): Dataset containing summary statistics-based quality controls.
@@ -707,6 +715,10 @@ class StudyIndex(Dataset):
             threshold_min_gc_lambda (float): Minimum threshold for GC lambda check. Defaults to 0.7.
             threshold_max_gc_lambda (float): Maximum threshold for GC lambda check. Defaults to 2.5.
             threshold_min_n_variants (int): Minimum number of variants for SuSiE check. Defaults to 2_000_000.
+            seq_threshold_mean_beta (float): Mean beta threshold for exome/wgs-gwas studies. Defaults to 1.0.
+            seq_threshold_min_gc_lambda (float): Minimum GC lambda threshold for exome/wgs-gwas studies. Defaults to 0.1.
+            seq_threshold_max_gc_lambda (float): Maximum GC lambda threshold for exome/wgs-gwas studies. Defaults to 2.5.
+            seq_threshold_min_n_variants (int): Minimum number of variants for exome/wgs-gwas studies. Defaults to 1_000_000.
 
         Returns:
             StudyIndex: Updated study index with QC information
@@ -735,6 +747,19 @@ class StudyIndex(Dataset):
             "sumstatQCValues", "QCCheckName", x, "QCCheckValue"
         )
 
+        # Studies sourced from exome or whole genome sequencing get relaxed thresholds:
+        if "analysisFlags" in studies.columns:
+            is_seq = f.coalesce(
+                f.array_contains("analysisFlags", StudyAnalysisFlag.EXWAS.value)
+                | f.array_contains("analysisFlags", StudyAnalysisFlag.WGS_WAS.value),
+                f.lit(False),
+            )
+        else:
+            is_seq = f.lit(False)
+        seq_or: Callable[[float, float], Column] = lambda seq_val, default_val: f.when(
+            is_seq, f.lit(seq_val)
+        ).otherwise(f.lit(default_val))
+
         df = (
             studies.drop("sumstatQCValues", "hasSumstats")
             .join(qc_df, how="left", on="studyId")
@@ -751,7 +776,10 @@ class StudyIndex(Dataset):
                 "qualityControls",
                 StudyIndex.update_quality_flag(
                     f.col("qualityControls"),
-                    ~(f.abs(extract_qc_value("mean_beta")) <= threshold_mean_beta),
+                    ~(
+                        f.abs(extract_qc_value("mean_beta"))
+                        <= seq_or(seq_threshold_mean_beta, threshold_mean_beta)
+                    ),
                     StudyQualityCheck.FAILED_MEAN_BETA_CHECK,
                 ),
             )
@@ -759,7 +787,9 @@ class StudyIndex(Dataset):
                 "qualityControls",
                 StudyIndex.update_quality_flag(
                     f.col("qualityControls"),
-                    ~(
+                    # PZ check is skipped for exome/wgs-gwas studies:
+                    ~is_seq
+                    & ~(
                         (
                             f.abs(extract_qc_value("mean_diff_pz"))
                             <= threshold_mean_diff_pz
@@ -774,8 +804,18 @@ class StudyIndex(Dataset):
                 StudyIndex.update_quality_flag(
                     f.col("qualityControls"),
                     ~(
-                        (extract_qc_value("gc_lambda") <= threshold_max_gc_lambda)
-                        & (extract_qc_value("gc_lambda") >= threshold_min_gc_lambda)
+                        (
+                            extract_qc_value("gc_lambda")
+                            <= seq_or(
+                                seq_threshold_max_gc_lambda, threshold_max_gc_lambda
+                            )
+                        )
+                        & (
+                            extract_qc_value("gc_lambda")
+                            >= seq_or(
+                                seq_threshold_min_gc_lambda, threshold_min_gc_lambda
+                            )
+                        )
                     ),
                     StudyQualityCheck.FAILED_GC_LAMBDA_CHECK,
                 ),
@@ -784,7 +824,8 @@ class StudyIndex(Dataset):
                 "qualityControls",
                 StudyIndex.update_quality_flag(
                     f.col("qualityControls"),
-                    extract_qc_value("n_variants") < threshold_min_n_variants,
+                    extract_qc_value("n_variants")
+                    < seq_or(seq_threshold_min_n_variants, threshold_min_n_variants),
                     StudyQualityCheck.SMALL_NUMBER_OF_SNPS,
                 ),
             )

--- a/tests/gentropy/dataset/test_study_index.py
+++ b/tests/gentropy/dataset/test_study_index.py
@@ -689,6 +689,46 @@ class TestStudyIndexAnnotation:
         )
         assert non_annotated[0][0] == [], "Should not be annotated with the flag"
 
+    def test_annotation_relaxed_thresholds_for_seq_studies(
+        self: TestStudyIndexAnnotation,
+    ) -> None:
+        """Exome/wgs-gwas studies get relaxed QC thresholds and skip the PZ check."""
+        # QC values that fail every default check but pass the relaxed ones:
+        qc_data = [
+            ("s1", 0.5, 0.5, 0.5, 0.5, 1, 1),  # case-case -> non-seq
+            ("s2", 0.5, 0.5, 0.5, 0.5, 1, 1),  # ExWAS -> seq
+            ("s3", 0.5, 0.5, 0.5, 0.5, 1, 1),  # case-case + ExWAS -> seq
+            ("s4", 0.5, 0.5, 0.5, 0.5, 1, 1),  # no flags -> non-seq
+        ]
+        qc_schema = SummaryStatisticsQC.get_schema()
+        qc = SummaryStatisticsQC(_df=self.spark.createDataFrame(qc_data, qc_schema))
+
+        si_df = self.spark.createDataFrame(
+            self.STUDY_WITH_ANALYSIS_FLAGS, self.STUDY_WITH_ANALYSIS_FLAGS_SCHEMA
+        )
+        study_index = StudyIndex(_df=si_df)
+
+        annotated = study_index.annotate_sumstats_qc(
+            qc,
+            **self.thresholds,
+            seq_threshold_mean_beta=1.0,
+            seq_threshold_min_gc_lambda=0.1,
+            seq_threshold_max_gc_lambda=2.5,
+            seq_threshold_min_n_variants=1,
+        )
+        flags = {
+            row["studyId"]: row["qualityControls"]
+            for row in annotated.df.select("studyId", "qualityControls").collect()
+        }
+        # Seq studies pass all relaxed checks:
+        assert flags["s2"] == [], "ExWAS study should not be flagged"
+        assert flags["s3"] == [], "case-case + ExWAS study should not be flagged"
+        # Non-seq studies still fail the strict checks:
+        assert StudyQualityCheck.FAILED_MEAN_BETA_CHECK.value in flags["s1"]
+        assert StudyQualityCheck.FAILED_PZ_CHECK.value in flags["s1"]
+        assert StudyQualityCheck.FAILED_GC_LAMBDA_CHECK.value in flags["s1"]
+        assert StudyQualityCheck.SMALL_NUMBER_OF_SNPS.value in flags["s4"]
+
     def test_validation_of_analysis_flags(
         self: TestStudyIndexAnnotation,
     ) -> None:


### PR DESCRIPTION
## Summary

Closes opentargets/issues#4416.

Studies whose `analysisFlags` contain `ExWAS` or `wgsGWAS` (exome / whole genome sequencing sources) now use relaxed thresholds in `StudyIndex.annotate_sumstats_qc`:

| check | default | seq (ExWAS/wgsGWAS) |
|-------|---------|---------------------|
| `mean_beta` | 0.05 | **1.0** |
| PZ (`mean_diff_pz` & `se_diff_pz`) | 0.05 | **skipped** |
| min `gc_lambda` | 0.7 | **0.1** |
| max `gc_lambda` | 2.5 | 2.5 |
| min `n_variants` | 2_000_000 | **1_000_000** |

New `seq_threshold_*` parameters carry the relaxed values; default (non-seq) behaviour is unchanged.

## Notes

- The issue also proposes sourcing `gc_lambda` for these studies from the Heritability step rather than the QC step. That is a larger change involving cross-step data flow and is left out of this small PR.

## Tests

- Added `test_annotation_relaxed_thresholds_for_seq_studies` — seq studies pass all relaxed checks while non-seq studies still fail the strict ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)