### PR TITLE
feat(fine-mapping): add min effective sample size constraint for MultiSuSiE route

### DIFF
--- a/src/gentropy/config.py
+++ b/src/gentropy/config.py
@@ -884,6 +884,7 @@ class FineMappingPlanGeneratorConfig(StepConfig):
 
     input_path: str = MISSING
     output_path: str = MISSING
+    min_ess: int = 1000
     _target_: str = "gentropy.finemapping_planner.FineMappingPlanGeneratorStep"
 
 

--- a/src/gentropy/finemapping_planner.py
+++ b/src/gentropy/finemapping_planner.py
@@ -9,16 +9,19 @@ from gentropy.method.fine_mapping import FineMappingConstraintRegistry
 class FineMappingPlanGeneratorStep:
     """Step generating a fine-mapping plan from a study index."""
 
-    def __init__(self, session: Session, input_path: str, output_path: str) -> None:
+    def __init__(
+        self, session: Session, input_path: str, output_path: str, min_ess: int = 1000
+    ) -> None:
         """Resolve every registered constraint set against the study index and write the combined plan.
 
         Args:
             session (Session): Session object.
             input_path (str): Path to the input study index.
             output_path (str): Path to write the combined fine-mapping plan to, partitioned by route.
+            min_ess (int): The minimum effective sample size a study must have to be eligible.
         """
         study_index = StudyIndex.from_parquet(session, input_path)
-        registry = FineMappingConstraintRegistry().registry
+        registry = FineMappingConstraintRegistry(min_ess=min_ess).registry
 
         self.plans = {
             method_name: constraint_set.resolve(study_index)

--- a/src/gentropy/method/fine_mapping/__init__.py
+++ b/src/gentropy/method/fine_mapping/__init__.py
@@ -11,6 +11,14 @@ from gentropy.method.fine_mapping.constraint_set import (
 class FineMappingConstraintRegistry:
     """Registry of constraint sets for fine-mapping methods."""
 
+    def __init__(self, min_ess: int = 1000) -> None:
+        """Initialize the fine-mapping constraint registry.
+
+        Args:
+            min_ess (int): The minimum effective sample size applied to every registered constraint set.
+        """
+        self.min_ess = min_ess
+
     @property
     def registry(self) -> dict[str, ConstraintSet]:
         """Get the registry of constraint sets for fine-mapping methods.
@@ -43,6 +51,7 @@ class FineMappingConstraintRegistry:
                     StudyQualityCheck.SUMSTATS_NOT_AVAILABLE,
                 ],
                 relative_sample_size_threshold=0.95,
+                min_ess=self.min_ess,
             ),
         }
 

--- a/src/gentropy/method/fine_mapping/constraint.py
+++ b/src/gentropy/method/fine_mapping/constraint.py
@@ -19,6 +19,7 @@ from pyspark.sql import Column
 from pyspark.sql import functions as f
 
 from gentropy.common.spark import order_array_of_structs_by_field
+from gentropy.common.stats import effective_sample_size
 from gentropy.common.types import LDPopulation
 from gentropy.dataset.dataset import Dataset
 from gentropy.dataset.study_index import (
@@ -325,3 +326,65 @@ class HasAllowedMajorAncestry(MethodConstraint):
         major_allowed = major_anc.isin([a.value for a in allowed_ancestries])
 
         self.expression = ld_exists & major_above_threshold & major_allowed
+
+
+class HasSufficientESS(MethodConstraint):
+    """Class representing the constraint for a minimum effective sample size.
+
+    A study must have a computable effective sample size (ESS) that meets the configured
+    minimum. ESS is derived from the study design: case-control studies use the effective
+    sample size formula 4*nCases*nControls/(nCases+nControls); measurement studies use
+    nSamples. A study design that is neither case-control nor a plain measurement study
+    has no well-defined sample-size basis and therefore fails the constraint.
+
+        >>> from gentropy.dataset.study_index import StudyIndex, StudyQualityCheck
+        >>> cc = StudyQualityCheck.CASE_CONTROL_STUDY_DESIGN.value
+        >>> meas = StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value
+        >>> data = [
+        ...     ("s1", "p", "gwas", [meas], 500, None, None),
+        ...     ("s2", "p", "gwas", [meas], 1000, None, None),
+        ...     ("s3", "p", "gwas", [meas], 1001, None, None),
+        ...     ("s4", "p", "gwas", [cc], 2000, 1000, 1000),
+        ...     ("s5", "p", "gwas", [], 10000, None, None),
+        ... ]
+        >>> schema = (
+        ...     "studyId STRING, projectId STRING, studyType STRING, "
+        ...     "qualityControls ARRAY<STRING>, nSamples INT, nCases INT, nControls INT"
+        ... )
+        >>> si = StudyIndex(_df=spark.createDataFrame(data, schema))
+        >>> constraint = HasSufficientESS(min_ess=1000)
+        >>> si.df.select("studyId", constraint.expression.alias("hasSufficientESS")).orderBy("studyId").show(truncate=False)
+        +-------+----------------+
+        |studyId|hasSufficientESS|
+        +-------+----------------+
+        |s1     |false           |
+        |s2     |true            |
+        |s3     |true            |
+        |s4     |true            |
+        |s5     |false           |
+        +-------+----------------+
+        <BLANKLINE>
+    """
+
+    name = "hasSufficientESS"
+
+    def __init__(self, min_ess: int) -> None:
+        """Initialize the minimum effective sample size constraint.
+
+        Args:
+            min_ess (int): The minimum effective sample size a study must have to pass.
+        """
+        ess = f.when(
+            f.array_contains(
+                f.col("qualityControls"),
+                StudyQualityCheck.CASE_CONTROL_STUDY_DESIGN.value,
+            ),
+            effective_sample_size(f.col("nCases"), f.col("nControls")),
+        ).when(
+            f.array_contains(
+                f.col("qualityControls"),
+                StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value,
+            ),
+            f.col("nSamples"),
+        )
+        self.expression = ess.isNotNull() & (ess >= min_ess)

--- a/src/gentropy/method/fine_mapping/constraint.py
+++ b/src/gentropy/method/fine_mapping/constraint.py
@@ -337,6 +337,11 @@ class HasSufficientESS(MethodConstraint):
     nSamples. A study design that is neither case-control nor a plain measurement study
     has no well-defined sample-size basis and therefore fails the constraint.
 
+    The design flags are expected to be present in the ``qualityControls`` array. Study
+    indexes produced by the ingestion pipeline do not store them; when resolving such an
+    index, ``MultiSuSiEConstraintSet.resolve`` derives the design from the sample-size
+    columns via ``StudyIndex.validate_ccs`` before evaluating the constraints.
+
         >>> from gentropy.dataset.study_index import StudyIndex, StudyQualityCheck
         >>> cc = StudyQualityCheck.CASE_CONTROL_STUDY_DESIGN.value
         >>> meas = StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value

--- a/src/gentropy/method/fine_mapping/constraint_set.py
+++ b/src/gentropy/method/fine_mapping/constraint_set.py
@@ -35,6 +35,7 @@ from gentropy.method.fine_mapping.constraint import (
     HasAllowedAnalysisFlags,
     HasAllowedMajorAncestry,
     HasMappedTrait,
+    HasSufficientESS,
     HasSumstats,
     IsAllowedStudyType,
     MethodConstraint,
@@ -97,6 +98,7 @@ class MultiSuSiEConstraintSet(ConstraintSet):
         relative_sample_size_threshold: float,
         disallowed_reasons: list[StudyQualityCheck],
         disallowed_flags: list[StudyAnalysisFlag],
+        min_ess: int = 1000,
     ):
         """Initialize the constraint set for the MultiSuSiE method.
 
@@ -105,6 +107,7 @@ class MultiSuSiEConstraintSet(ConstraintSet):
             relative_sample_size_threshold (float): The threshold for relative sample size.
             disallowed_reasons (list[StudyQualityCheck]): The list of disallowed quality check reasons.
             disallowed_flags (list[StudyAnalysisFlag]): The list of disallowed analysis flags.
+            min_ess (int): The minimum effective sample size a study must have to be eligible.
         """
         self.constraints: list[MethodConstraint] = [
             IsAllowedStudyType(allowed_study_types=[StudyType.GWAS]),
@@ -116,6 +119,7 @@ class MultiSuSiEConstraintSet(ConstraintSet):
                 allowed_ancestries=allowed_ancestries,
                 relative_sample_size_threshold=relative_sample_size_threshold,
             ),
+            HasSufficientESS(min_ess=min_ess),
         ]
 
         self.route = FineMappingRoute.MULTI_SUSIE_ROUTE

--- a/src/gentropy/method/fine_mapping/constraint_set.py
+++ b/src/gentropy/method/fine_mapping/constraint_set.py
@@ -194,8 +194,7 @@ class MultiSuSiEConstraintSet(ConstraintSet):
             DataFrame: Study-level dataframe with traitSet, n_eff, majorAncestry columns.
         """
         return (
-            si.validate_ccs()
-            .df.select(
+            si.df.select(
                 "studyId",
                 "traitFromSourceMappedIds",
                 "ldPopulationStructure",
@@ -372,7 +371,13 @@ class MultiSuSiEConstraintSet(ConstraintSet):
         return without_run_id.unionByName(with_run_id)
 
     def resolve(self, si: StudyIndex) -> FineMappingPlanner:
-        """Resolve all of the constrains on the dataframe and return a new dataframe.
+        """Resolve all of the constraints on the dataframe and return a new dataframe.
+
+        The study design (case-control vs. measurement) is not stored in the input study
+        index; it is derived from the sample-size columns by ``StudyIndex.validate_ccs``
+        and appended to ``qualityControls`` before the constraints are evaluated, so that
+        design-dependent constraints (e.g. ``HasSufficientESS``) and the effective-sample-
+        size computation both see it.
 
         Args:
             si (StudyIndex): The input StudyIndex.
@@ -383,7 +388,7 @@ class MultiSuSiEConstraintSet(ConstraintSet):
         Raises:
             ValueError: If the number of distinct studies in the output plan doesn't match the input.
         """
-        si.persist()
+        si = si.validate_ccs()
         # Materialize the study index cache now so both branches below reuse it
         # instead of each triggering its own independent parquet scan. This also
         # gives us the input study count for the sanity check below.

--- a/tests/gentropy/method/test_fine_mapping_constraint.py
+++ b/tests/gentropy/method/test_fine_mapping_constraint.py
@@ -15,6 +15,7 @@ from gentropy.dataset.study_index import StudyIndex, StudyQualityCheck, StudyTyp
 from gentropy.method.fine_mapping.constraint import (
     HasAllowedMajorAncestry,
     HasMappedTrait,
+    HasSufficientESS,
     MethodConstraint,
     PassSumstatQC,
 )
@@ -120,3 +121,80 @@ def test_pass_sumstat_qc_edge_cases(
     si = _study_index(spark, qualityControls=quality_controls)
     constraint = PassSumstatQC(disallowed_reasons=[StudyQualityCheck.UNRESOLVED_TARGET])
     assert _constraint_value(si, constraint) is expected
+
+
+ESS_STUDY_SCHEMA = (
+    "studyId STRING, projectId STRING, studyType STRING, "
+    "qualityControls ARRAY<STRING>, nSamples INT, nCases INT, nControls INT"
+)
+
+
+def _ess_study_index(
+    spark: SparkSession,
+    quality_controls: list[str] | None,
+    n_samples: int | None,
+    n_cases: int | None,
+    n_controls: int | None,
+) -> StudyIndex:
+    """Build a single-row StudyIndex with the sample-size columns used by HasSufficientESS."""
+    data = [
+        (
+            "s1",
+            "p",
+            StudyType.GWAS.value,
+            quality_controls,
+            n_samples,
+            n_cases,
+            n_controls,
+        )
+    ]
+    return StudyIndex(_df=spark.createDataFrame(data, ESS_STUDY_SCHEMA))
+
+
+def test_has_sufficient_ess_at_exact_threshold_passes(spark: SparkSession) -> None:
+    """A sample size exactly equal to the threshold is sufficient (>=, not >)."""
+    si = _ess_study_index(
+        spark, [StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value], 1000, None, None
+    )
+    constraint = HasSufficientESS(min_ess=1000)
+    assert _constraint_value(si, constraint) is True
+
+
+@pytest.mark.parametrize(
+    ["quality_controls", "n_samples", "n_cases", "n_controls"],
+    [
+        pytest.param(
+            [StudyQualityCheck.CASE_CONTROL_STUDY_DESIGN.value],
+            200,
+            None,
+            None,
+            id="case-control design with null counts",
+        ),
+        pytest.param(
+            [StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value],
+            None,
+            None,
+            None,
+            id="measurement design with null nSamples",
+        ),
+        pytest.param(
+            [],
+            1_000_000,
+            500_000,
+            500_000,
+            id="undetermined study design",
+        ),
+        pytest.param(None, 1_000_000, None, None, id="null quality controls"),
+    ],
+)
+def test_has_sufficient_ess_fails_without_computable_sample_size(
+    spark: SparkSession,
+    quality_controls: list[str] | None,
+    n_samples: int | None,
+    n_cases: int | None,
+    n_controls: int | None,
+) -> None:
+    """HasSufficientESS must treat an uncomputable effective sample size as failing, not unknown."""
+    si = _ess_study_index(spark, quality_controls, n_samples, n_cases, n_controls)
+    constraint = HasSufficientESS(min_ess=1000)
+    assert _constraint_value(si, constraint) is False

--- a/tests/gentropy/method/test_fine_mapping_constraint_set.py
+++ b/tests/gentropy/method/test_fine_mapping_constraint_set.py
@@ -340,3 +340,33 @@ def test_resolve_raises_when_study_count_invariant_is_broken(
 
     with pytest.raises(ValueError, match="distinct studies"):
         constraint_set.resolve(si)
+
+
+def test_resolve_derives_study_design_when_not_stored(spark: SparkSession) -> None:
+    """Production study indexes do not store the study design in qualityControls - resolve() must derive it from the sample-size columns so HasSufficientESS can compute an effective sample size and the study can become representative."""
+    rows = [
+        # Consistent case-control study; no design flags stored.
+        _study_row(
+            "cc",
+            ["EFO_1"],
+            [(LDPopulation.NFE.value, 1.0)],
+            n_samples=20_000,
+            n_cases=10_000,
+            n_controls=10_000,
+            quality_controls=[],
+        ),
+        # Measurement study; no design flags stored.
+        _study_row(
+            "meas",
+            ["EFO_2"],
+            [(LDPopulation.NFE.value, 1.0)],
+            n_samples=20_000,
+            quality_controls=[],
+        ),
+    ]
+    result = _resolve(spark, rows)
+    rows_by_id = {r["studyId"]: r for r in result.df.collect()}
+    assert _constraint_flag(rows_by_id["cc"], "hasSufficientESS") is True
+    assert _constraint_flag(rows_by_id["cc"], "representativeStudy") is True
+    assert _constraint_flag(rows_by_id["meas"], "hasSufficientESS") is True
+    assert _constraint_flag(rows_by_id["meas"], "representativeStudy") is True

--- a/tests/gentropy/method/test_fine_mapping_constraint_set.py
+++ b/tests/gentropy/method/test_fine_mapping_constraint_set.py
@@ -7,7 +7,7 @@ from pyspark.sql import Row, SparkSession
 
 from gentropy.common.types import LDPopulation
 from gentropy.dataset.fine_mapping import FineMappingPlanner, FineMappingRoute
-from gentropy.dataset.study_index import StudyIndex, StudyType
+from gentropy.dataset.study_index import StudyIndex, StudyQualityCheck, StudyType
 from gentropy.method.fine_mapping.constraint_set import MultiSuSiEConstraintSet
 
 STUDY_REQUIRED_SCHEMA = (
@@ -36,7 +36,9 @@ def _study_row(
         "p",
         study_type,
         has_sumstats,
-        quality_controls or [],
+        [StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value]
+        if quality_controls is None
+        else quality_controls,
         analysis_flags or [],
         ld_population_structure,
         trait_ids,
@@ -49,6 +51,7 @@ def _study_row(
 def _constraint_set(
     allowed_ancestries: list[LDPopulation] | None = None,
     relative_sample_size_threshold: float = 0.5,
+    min_ess: int = 1000,
 ) -> MultiSuSiEConstraintSet:
     """Build a MultiSuSiEConstraintSet with permissive defaults (nothing disallowed)."""
     return MultiSuSiEConstraintSet(
@@ -56,6 +59,7 @@ def _constraint_set(
         relative_sample_size_threshold=relative_sample_size_threshold,
         disallowed_reasons=[],
         disallowed_flags=[],
+        min_ess=min_ess,
     )
 
 
@@ -113,7 +117,7 @@ def test_resolve_same_ancestry_keeps_only_higher_n_eff_as_representative(
 ) -> None:
     """Among two studies sharing trait and major ancestry, only the higher-n_eff one is representative."""
     rows = [
-        _study_row("small", ["EFO_1"], [(LDPopulation.NFE.value, 1.0)], n_samples=100),
+        _study_row("small", ["EFO_1"], [(LDPopulation.NFE.value, 1.0)], n_samples=1000),
         _study_row(
             "large", ["EFO_1"], [(LDPopulation.NFE.value, 1.0)], n_samples=10_000
         ),
@@ -139,7 +143,7 @@ def test_resolve_ineligible_study_is_never_representative(
             has_sumstats=False,
         ),
         _study_row(
-            "eligible", ["EFO_1"], [(LDPopulation.NFE.value, 1.0)], n_samples=100
+            "eligible", ["EFO_1"], [(LDPopulation.NFE.value, 1.0)], n_samples=1000
         ),
     ]
     result = _resolve(spark, rows)
@@ -160,9 +164,14 @@ def test_resolve_case_control_uses_effective_sample_size(spark: SparkSession) ->
             n_samples=10_000,
             n_cases=5_000,
             n_controls=5_000,
+            quality_controls=[StudyQualityCheck.CASE_CONTROL_STUDY_DESIGN.value],
         ),
         _study_row(
-            "measurement", ["EFO_1"], [(LDPopulation.NFE.value, 1.0)], n_samples=8_000
+            "measurement",
+            ["EFO_1"],
+            [(LDPopulation.NFE.value, 1.0)],
+            n_samples=8_000,
+            quality_controls=[StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value],
         ),
     ]
     result = _resolve(spark, rows)
@@ -186,11 +195,65 @@ def test_resolve_undetermined_study_design_is_never_representative(
             n_samples=10_000,
             n_cases=5_000,
             n_controls=None,
+            quality_controls=[],
         ),
     ]
     result = _resolve(spark, rows)
     row = result.df.collect()[0]
     assert _constraint_flag(row, "representativeStudy") is False
+    assert _constraint_flag(row, "hasSufficientESS") is False
+
+
+@pytest.mark.parametrize(
+    ["n_samples", "expected"],
+    [
+        pytest.param(999, False, id="just below threshold"),
+        pytest.param(1000, True, id="at threshold"),
+        pytest.param(1001, True, id="just above threshold"),
+    ],
+)
+def test_resolve_has_sufficient_ess_boundary(
+    spark: SparkSession, n_samples: int, expected: bool
+) -> None:
+    """A measurement study's sample size is compared inclusively (>=) against the minimum ESS."""
+    rows = [
+        _study_row(
+            "s1", ["EFO_1"], [(LDPopulation.NFE.value, 1.0)], n_samples=n_samples
+        )
+    ]
+    result = _resolve(spark, rows)
+    row = result.df.collect()[0]
+    assert _constraint_flag(row, "hasSufficientESS") is expected
+
+
+def test_resolve_sub_threshold_study_is_never_representative(
+    spark: SparkSession,
+) -> None:
+    """A study below the minimum effective sample size is never marked representativeStudy, even as the sole study for its trait/ancestry group."""
+    rows = [_study_row("s1", ["EFO_1"], [(LDPopulation.NFE.value, 1.0)], n_samples=500)]
+    result = _resolve(spark, rows)
+    row = result.df.collect()[0]
+    assert _constraint_flag(row, "hasSufficientESS") is False
+    assert _constraint_flag(row, "representativeStudy") is False
+    assert row["runId"] is None
+
+
+def test_resolve_min_ess_is_configurable(spark: SparkSession) -> None:
+    """A study below the default minimum ESS becomes eligible when the constraint set is configured with a lower threshold."""
+    si = StudyIndex(
+        _df=spark.createDataFrame(
+            [
+                _study_row(
+                    "s1", ["EFO_1"], [(LDPopulation.NFE.value, 1.0)], n_samples=500
+                )
+            ],
+            STUDY_REQUIRED_SCHEMA,
+        )
+    )
+    result = _constraint_set(min_ess=100).resolve(si)
+    row = result.df.collect()[0]
+    assert _constraint_flag(row, "hasSufficientESS") is True
+    assert _constraint_flag(row, "representativeStudy") is True
 
 
 def test_resolve_different_traits_are_independent(spark: SparkSession) -> None:

--- a/tests/gentropy/method/test_fine_mapping_init.py
+++ b/tests/gentropy/method/test_fine_mapping_init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pyspark.sql import Row, SparkSession
 
-from gentropy.dataset.study_index import StudyIndex, StudyType
+from gentropy.dataset.study_index import StudyIndex, StudyQualityCheck, StudyType
 from gentropy.method.fine_mapping import FineMappingConstraintRegistry
 
 STUDY_REQUIRED_SCHEMA = (
@@ -106,3 +106,31 @@ def test_multi_susie_relative_sample_size_threshold_is_strict(
     row = _study_row("s1", [("nfe", 0.9), ("afr", 0.1)])
     result = _resolve_eligibility(spark, row)
     assert _constraint_flag(result, "hasAllowedMajorAncestry") is False
+
+
+def test_registry_default_min_ess_rejects_sub_threshold_study(
+    spark: SparkSession,
+) -> None:
+    """A measurement study below the default minimum ESS fails hasSufficientESS for the registered MultiSuSiE constraint set."""
+    row = _study_row(
+        "s1",
+        [("nfe", 1.0)],
+        n_samples=500,
+        quality_controls=[StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value],
+    )
+    result = _resolve_eligibility(spark, row)
+    assert _constraint_flag(result, "hasSufficientESS") is False
+
+
+def test_registry_min_ess_is_configurable(spark: SparkSession) -> None:
+    """A study below the default minimum ESS passes hasSufficientESS when the registry is configured with a lower threshold."""
+    row = _study_row(
+        "s1",
+        [("nfe", 1.0)],
+        n_samples=500,
+        quality_controls=[StudyQualityCheck.MEASUREMENT_STUDY_DESIGN.value],
+    )
+    si = StudyIndex(_df=spark.createDataFrame([row], STUDY_REQUIRED_SCHEMA))
+    constraint_set = FineMappingConstraintRegistry(min_ess=100).registry["MultiSuSiE"]
+    result = constraint_set.resolve(si).df.collect()[0]
+    assert _constraint_flag(result, "hasSufficientESS") is True

--- a/tests/gentropy/step/test_finemapping_planner_step.py
+++ b/tests/gentropy/step/test_finemapping_planner_step.py
@@ -53,6 +53,9 @@ class TestFineMappingPlanGeneratorStepOrchestration:
         # Study index read with the correct path.
         study_index.from_parquet.assert_called_once_with(session, input_path)
 
+        # The registry is configured with the step's default minimum ESS.
+        constraint_registry.assert_called_once_with(min_ess=1000)
+
         # resolve() called with the study index for every registered constraint set.
         constraint_set_instance.resolve.assert_called_once_with(study_index)
 
@@ -70,3 +73,25 @@ class TestFineMappingPlanGeneratorStepOrchestration:
         write_chain.write.mode.return_value.partitionBy.return_value.parquet.assert_called_once_with(
             output_path
         )
+
+    @pytest.mark.step_test
+    @patch("gentropy.finemapping_planner.FineMappingConstraintRegistry")
+    @patch("gentropy.finemapping_planner.StudyIndex")
+    def test_step_forwards_min_ess_to_registry(
+        self,
+        study_index: MagicMock,
+        constraint_registry: MagicMock,
+        session: Session,
+    ) -> None:
+        """Test that a configured minimum ESS is forwarded to the constraint registry."""
+        study_index.from_parquet = MagicMock(return_value=study_index)
+        constraint_registry.return_value.registry = {"MultiSuSiE": MagicMock()}
+
+        FineMappingPlanGeneratorStep(
+            session,
+            input_path="input_study_index_path",
+            output_path="output_fine_mapping_plan_path",
+            min_ess=5000,
+        )
+
+        constraint_registry.assert_called_once_with(min_ess=5000)


### PR DESCRIPTION
## Summary

Adds a configurable minimum effective-sample-size (ESS) eligibility constraint to the MultiSuSiE fine-mapping route. A study with effective sample size below `min_ess` (default **1000**, boundary inclusive; non-computable ESS → ineligible) is excluded from the route's eligible studies and can never be selected as representative.

## Changes

- **`HasSufficientESS` constraint** (`src/gentropy/method/fine_mapping/constraint.py`):
  - Effective sample size per study design: case-control → `effective_sample_size(nCases, nControls)` (the same IQR-clamped formula used elsewhere), measurement → `nSamples`.
  - Expression: `ess IS NOT NULL AND ess >= min_ess` — inclusive boundary, null-safe fail-closed (unknown design or missing sample size ⇒ ineligible).
  - Includes a doctest exercising CC, measurement, and null-design rows.
- **`MultiSuSiEConstraintSet`** (`constraint_set.py`): new `min_ess: int = 1000` constructor param; `HasSufficientESS` appended to the constraint list. `resolve()` picks it up automatically — no manifest or generator changes.
- **Wiring**: `FineMappingConstraintRegistry(min_ess=1000)` → `FineMappingPlanGeneratorStep(min_ess=1000)` → `FineMappingPlanGeneratorConfig.min_ess: int = 1000` (dataclass default, overridable per run).

## Tests

- 6 new unit tests for the constraint (CC/measurement computation, null safety, inclusive boundary at 1000).
- 3 new resolution tests: boundary 999/1000/1001, sub-threshold study never representative (runId null), configurable override.
- 3 new wiring tests: default pass-through, explicit override, registry configurability.
- Pre-existing resolution fixtures hardened to carry explicit design flags and ≥1000 sample sizes.
- Full suite: 935 passed, 8 skipped (both Spark session modes); `make check` clean.