### PR TITLE
fix: dockerfile update to account for batch env override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV CLOUDSDK_PYTHON=/usr/local/bin/python3
 
+# Google Batch injects CLOUDSDK_PYTHON=/usr/bin/python3 into container runnables,
+# overriding image-level ENV. This base image ships python at /usr/local/bin only,
+# so provide the conventional system path for gcloud (and anything else hardcoding it).
+RUN ln -sf /usr/local/bin/python3 /usr/bin/python3
+
 # Create app user and group
 RUN groupadd --gid 1000 app && \
     useradd --uid 1000 --gid app --shell /bin/bash --create-home app


### PR DESCRIPTION
## ✨ Context

gwas_catalog_sumstat_harmonisation was switched from the standalone orchestration-harmonisation image to the gentropy image, so that harmonisation and QC run against the same gentropy build as the rest of the
  pipeline. Following #1278 (which added the Google Cloud CLI and utils/harmonise_sumstats.sh to the runtime stage), every Google Batch task failed immediately.

Google Batch injects CLOUDSDK_PYTHON=/usr/bin/python3 into container runnables, and an injected variable overrides the image's ENV. Confirmed by dumping the environment from inside a Batch task. 

## 🛠 What does this PR implement

Adds a symlink in the runtime stage so the path Batch points gcloud at resolves to a real interpreter.

## 🙈 Missing

<!--- If there are things that are requested in the task and were not implemented, list them here -->

## 🚦 Before submitting

- [ ] Do these changes cover one single feature (one change at a time)?
- [ ] Did you read the [contributor guideline](https://opentargets.github.io/gentropy/development/contributing/#contributing-checklist)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you make sure there is no commented out code in this PR?
- [ ] Did you follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standards in PR title and commit messages?
- [ ] Did you make sure the branch is up-to-date with the `dev` branch?
- [ ] Did you write any new necessary tests?
- [ ] Did you make sure the changes pass local tests (`make test`)?
- [ ] Did you make sure the changes pass pre-commit rules (e.g `uv run pre-commit run --all-files`)?
