### PR TITLE
fix(l2g): compute average precision from probabilities

### DIFF
--- a/src/gentropy/method/l2g/trainer.py
+++ b/src/gentropy/method/l2g/trainer.py
@@ -485,7 +485,8 @@ class LocusToGeneTrainer:
         Args:
             y_true (np.ndarray): True labels
             y_pred (np.ndarray): Predicted labels
-            y_pred_proba (np.ndarray): Predicted probabilities for the positive class
+            y_pred_proba (np.ndarray): Class probabilities, shape (n_samples, 2). Column 1 holds
+                the probability of the positive class and is what the threshold-free metrics use.
 
         Returns:
             dict[str, float]: Dictionary of evaluation metrics
@@ -498,9 +499,10 @@ class LocusToGeneTrainer:
             ),
             "accuracy": accuracy_score(y_true, y_pred),
             "weightedPrecision": precision_score(y_true, y_pred, average="weighted"),
-            "averagePrecision": average_precision_score(
-                y_true, y_pred, average="weighted"
-            ),
+            # Average precision summarises the whole precision-recall curve, so it needs the
+            # scores rather than the thresholded labels. Given 0/1 predictions the curve has a
+            # single interior point and the area comes out far below the model's real value.
+            "averagePrecision": average_precision_score(y_true, y_pred_proba[:, 1]),
             "weightedRecall": recall_score(y_true, y_pred, average="weighted"),
             "f1": f1_score(y_true, y_pred, average="weighted"),
             "TP": tp,

--- a/tests/gentropy/method/test_l2g_trainer.py
+++ b/tests/gentropy/method/test_l2g_trainer.py
@@ -48,6 +48,36 @@ def test_evaluate_perfect_predictions() -> None:
     assert metrics == expected
 
 
+def test_average_precision_uses_probabilities_not_labels() -> None:
+    """Test that average precision reads the scores rather than the thresholded predictions.
+
+    The model ranks every positive above every negative, so average precision is 1.0. It only
+    gets that right if it reads the probabilities: computed from the 0/1 predictions instead, the
+    two false positives at the 0.5 threshold drag it down to 0.5.
+    """
+    y_true = np.array([1, 1, 0, 0])
+    y_pred_proba = np.array(
+        [
+            [0.1, 0.9],
+            [0.2, 0.8],
+            [
+                0.3,
+                0.7,
+            ],  # ranked below both positives, but still above the 0.5 threshold
+            [0.4, 0.6],
+        ]
+    )
+    y_pred = (y_pred_proba[:, 1] >= 0.5).astype(int)
+
+    metrics = LocusToGeneTrainer.evaluate(y_true, y_pred, y_pred_proba)
+
+    assert metrics["averagePrecision"] == pytest.approx(1.0)
+    # The ranking is perfect, so the two threshold-free metrics have to agree.
+    assert metrics["averagePrecision"] == pytest.approx(metrics["areaUnderROC"])
+    # ...while the threshold-dependent metrics do see the two false positives.
+    assert (metrics["TP"], metrics["FP"], metrics["TN"], metrics["FN"]) == (2, 2, 0, 0)
+
+
 def test_train(mock_l2g_feature_matrix: L2GFeatureMatrix) -> None:
     """Test LocusToGeneTrainer.train produces a fitted model."""
     features_list = ["distanceTssMean", "distanceSentinelTssMinimum"]


### PR DESCRIPTION
`LocusToGeneTrainer.evaluate` passes the thresholded 0/1 predictions to `average_precision_score` instead of the positive-class probabilities:

```python
"areaUnderROC": roc_auc_score(y_true, y_pred_proba[:, 1], average="weighted"),
...
"averagePrecision": average_precision_score(y_true, y_pred, average="weighted"),
#                                                   ^^^^^^ hard labels
```

Average precision is the area under a precision-recall curve, so it needs scores. Given 0/1 labels the curve has a single interior point and the area collapses towards it.

## Impact

Every L2G model's reported average precision has been too low. On a 26.06 model evaluated over 29,761 held-out rows the metric reads **0.6343 where the true value is 0.8297**. On an imbalanced set — 2,422 positives against 27,339 negatives — average precision is the headline metric, so this matters for model comparison and for anything recorded in W&B.

The two threshold-free metrics were also inconsistent inside one function: `areaUnderROC` on the line above already reads `y_pred_proba[:, 1]`.

Nothing else changes. `accuracy`, `weightedPrecision`, `weightedRecall`, `f1` and the confusion matrix are threshold-dependent by definition and still read `y_pred`.

## The `average` argument

Dropped along with it. sklearn ignores `average` for binary targets, so it never did anything here, and leaving it in place suggested the call had been thought about when it had not.

## Test

The existing `test_evaluate_perfect_predictions` cannot catch this — when predictions and ranking agree, both readings give 1.0.

The new test uses a **perfect ranking with two false positives at the 0.5 threshold**: every positive scores above every negative, so average precision must be 1.0, while the confusion matrix correctly records `FP=2`. The old code returns 0.5.

## Provenance

Found while benchmarking a new L2G feature on release 26.06, where the reported and recomputed average precision disagreed. Two other pre-existing defects surfaced in the same run and are in separate PRs: `DataFrame.persist()` failing on Dataproc, and `LocusToGeneModel.load_from_disk` mangling `gs://` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)