### PR TITLE
fix(l2g): load a model from a GCS directory

### DIFF
--- a/src/gentropy/method/l2g/model.py
+++ b/src/gentropy/method/l2g/model.py
@@ -80,11 +80,15 @@ class LocusToGeneModel:
         Raises:
             ValueError: If the model has not been fitted yet
         """
-        model_path = (Path(path) / model_name).as_posix()
+        # Joined as a string rather than through pathlib: Path collapses the double slash in a
+        # URI, turning "gs://bucket/dir" into "gs:/bucket/dir", so the check below would never
+        # fire and a GCS directory would be read off the local filesystem.
+        model_path = f"{path.rstrip('/')}/{model_name}"
+        # Only the local branch looks for the training data alongside the model, so this has to
+        # be bound up front or the GCS branch fails on the return below.
+        training_data = None
         if model_path.startswith("gs://"):
-            path = model_path.removeprefix("gs://")
-            bucket_name = path.split("/")[0]
-            blob_name = "/".join(path.split("/")[1:])
+            bucket_name, blob_name = model_path.removeprefix("gs://").split("/", 1)
             from google.cloud import storage
 
             client = storage.Client()

--- a/tests/gentropy/method/test_l2g_model.py
+++ b/tests/gentropy/method/test_l2g_model.py
@@ -1,0 +1,64 @@
+"""Tests on the L2G model wrapper."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import skops.io as sio
+from xgboost import XGBClassifier
+
+from gentropy.method.l2g.model import LocusToGeneModel
+
+if TYPE_CHECKING:
+    from gentropy.common.session import Session
+
+
+@pytest.fixture()
+def fitted_model_bytes() -> bytes:
+    """A minimal fitted classifier, serialised the way `save` writes it."""
+    model = XGBClassifier(n_estimators=2, max_depth=2)
+    model.fit(np.array([[0.0], [1.0], [0.0], [1.0]]), np.array([0, 1, 0, 1]))
+    return sio.dumps(model)
+
+
+def test_load_from_disk_reads_a_gcs_directory(
+    session: Session, fitted_model_bytes: bytes
+) -> None:
+    """Test that a gs:// directory is resolved to the right bucket and blob.
+
+    Building the path with pathlib collapses "gs://bucket/dir" to "gs:/bucket/dir", which sends
+    the read down the local-filesystem branch and fails. This pins the bucket and blob names the
+    GCS branch asks for.
+    """
+    blob = MagicMock()
+    blob.download_as_string.return_value = fitted_model_bytes
+    storage = MagicMock()
+    storage.Blob.return_value = blob
+
+    with (
+        patch.dict("sys.modules", {"google.cloud": MagicMock(storage=storage)}),
+        patch("google.cloud.storage", storage),
+    ):
+        model = LocusToGeneModel.load_from_disk(session, "gs://a-bucket/some/model/dir")
+
+    assert isinstance(model.model, XGBClassifier)
+    assert storage.Bucket.call_args.kwargs["name"] == "a-bucket"
+    assert storage.Blob.call_args.kwargs["name"] == "some/model/dir/classifier.skops"
+
+
+def test_load_from_disk_reads_a_local_directory(
+    session: Session, fitted_model_bytes: bytes, tmp_path: object
+) -> None:
+    """Test that a local directory still works, and that a trailing slash is tolerated."""
+    from pathlib import Path
+
+    directory = Path(str(tmp_path)) / "model"
+    directory.mkdir()
+    (directory / "classifier.skops").write_bytes(fitted_model_bytes)
+
+    for given in (directory.as_posix(), directory.as_posix() + "/"):
+        model = LocusToGeneModel.load_from_disk(session, given)
+        assert isinstance(model.model, XGBClassifier)


### PR DESCRIPTION
`LocusToGeneModel.load_from_disk` could never read a model from GCS. Two defects on the same path.

## 1. pathlib eats the URI

```python
model_path = (Path(path) / model_name).as_posix()
if model_path.startswith("gs://"):
```

`Path` normalises the double slash, so `gs://bucket/dir` becomes `gs:/bucket/dir`:

```python
>>> (Path("gs://bucket/dir") / "classifier.skops").as_posix()
'gs:/bucket/dir/classifier.skops'
```

The `startswith("gs://")` check therefore never fires for a GCS directory, and the read falls through to the local branch, which tries to open `gs:/...` on the local filesystem.

## 2. `training_data` is unbound on the GCS branch

With the path fixed, the GCS branch then raises:

```
UnboundLocalError: cannot access local variable 'training_data' where it is not associated with a value
```

`training_data` is only assigned inside the `else` branch, and the shared `return cls(..., training_data=training_data, ...)` reads it either way. Because defect 1 meant the GCS branch was unreachable, this had never surfaced.

## Fix

The path is joined as a string, which leaves URIs intact and tolerates a trailing slash, and `training_data` is bound before the branch.

Local behaviour is unchanged: the training data is still picked up from `train.parquet` and `test.parquet` beside the model when they exist, and is `None` for GCS, where those files are not fetched — which is what the GCS branch would have done anyway had it ever run.

## Tests

New `tests/gentropy/method/test_l2g_model.py`:

- **GCS** — patches `google.cloud.storage` and pins the bucket and blob names the branch asks for (`a-bucket`, `some/model/dir/classifier.skops`). Fails on `main` with the `UnboundLocalError` above, since the path fix alone is not enough to reach a passing state.
- **Local** — round-trips a real fitted classifier through a temporary directory, with and without a trailing slash.

## Provenance

Found while loading a model back from GCS to evaluate it after training. Two other pre-existing defects surfaced in the same run and are in separate PRs: average precision computed from hard predictions (#1283), and `DataFrame.persist()` failing on Dataproc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)