### PR TITLE
fix: fall back to cache where persist cannot build a StorageLevel

### DIFF
--- a/src/gentropy/common/spark.py
+++ b/src/gentropy/common/spark.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import operator
 import re
 from collections.abc import Callable, Iterable
@@ -1040,3 +1041,42 @@ def all_struct_fields_in_array(
         f.lit(True),
         lambda acc, x: acc & (x[struct_field] == value),
     )
+
+
+def persist_dataframe(df: DataFrame) -> DataFrame:
+    """Persist a dataframe, falling back to `cache` where `persist` cannot run.
+
+    `DataFrame.persist` builds a Java `StorageLevel` from Python, and on some Spark
+    distributions py4j cannot reach that constructor because it is `private[spark]` in Scala.
+    Dataproc image 2.2 is one of them, and the call dies with::
+
+        py4j.Py4JException: Constructor org.apache.spark.storage.StorageLevel(
+          [Boolean, Boolean, Boolean, Boolean, Integer]) does not exist
+
+    This is not a version skew: aligning the pyspark client to the cluster's Spark version does
+    not change it. `DataFrame.cache` calls `_jdf.cache()` straight on the JVM and never builds a
+    `StorageLevel`, so it works where `persist` does not, and it uses the same storage level that
+    a no-argument `persist` asks for.
+
+    Every gentropy caller persists at the default level, so the fallback is equivalent rather
+    than a downgrade. `persist` is still tried first, making this a no-op wherever it works.
+
+    Args:
+        df (DataFrame): Dataframe to persist.
+
+    Returns:
+        DataFrame: The same dataframe, marked for caching.
+
+    Examples:
+        >>> df = spark.createDataFrame([(1,)], "a int")
+        >>> persist_dataframe(df).is_cached
+        True
+        >>> df.unpersist() and None
+    """
+    try:
+        return df.persist()
+    except Exception as error:  # noqa: BLE001 - fall back on any persist-time failure
+        logging.warning(
+            "DataFrame.persist() failed (%s); falling back to DataFrame.cache().", error
+        )
+        return df.cache()

--- a/src/gentropy/dataset/dataset.py
+++ b/src/gentropy/dataset/dataset.py
@@ -16,6 +16,7 @@ from pyspark.sql.window import Window
 
 from gentropy.common.schemas import SchemaValidationError, compare_struct_schemas
 from gentropy.common.session import Session
+from gentropy.common.spark import persist_dataframe
 
 if TYPE_CHECKING:
     from pyspark.sql import Column
@@ -327,7 +328,7 @@ class Dataset(ABC):
         Returns:
             Self: Persisted Dataset
         """
-        self.df = self._df.persist()
+        self.df = persist_dataframe(self._df)
         return self
 
     def unpersist(self: Self) -> Self:

--- a/src/gentropy/dataset/l2g_feature_matrix.py
+++ b/src/gentropy/dataset/l2g_feature_matrix.py
@@ -9,7 +9,7 @@ import pyspark.sql.functions as f
 from pandas import DataFrame as pd_dataframe
 from pyspark.sql import Window
 
-from gentropy.common.spark import convert_from_long_to_wide
+from gentropy.common.spark import convert_from_long_to_wide, persist_dataframe
 from gentropy.dataset.l2g_gold_standard import L2GGoldStandard
 from gentropy.method.l2g.feature_factory import FeatureFactory, L2GFeatureInputLoader
 
@@ -203,7 +203,7 @@ class L2GFeatureMatrix:
         Returns:
             Self: Persisted Dataset
         """
-        self._df = self._df.persist()
+        self._df = persist_dataframe(self._df)
         return self
 
     def append_null_features(self, features_list: list[str]) -> L2GFeatureMatrix:

--- a/src/gentropy/dataset/l2g_features/intervals.py
+++ b/src/gentropy/dataset/l2g_features/intervals.py
@@ -8,7 +8,7 @@ import pyspark.sql.functions as f
 from pyspark.sql import DataFrame, Window
 
 from gentropy.common.processing import extract_chromosome, extract_position
-from gentropy.common.spark import convert_from_wide_to_long
+from gentropy.common.spark import convert_from_wide_to_long, persist_dataframe
 from gentropy.dataset.intervals import Intervals
 from gentropy.dataset.l2g_features.l2g_feature import L2GFeature
 from gentropy.dataset.l2g_gold_standard import L2GGoldStandard
@@ -183,13 +183,13 @@ def e2g_interval_feature_wide_logic_binned(
     )
 
     # Weight and aggregate to gene per locus
-    base_df = (
+    base_df = persist_dataframe(
         per_variant_gene.withColumn(
             "weightedIntervalScore", f.col("maxScore") * f.col("pp")
         )
         .groupBy("studyLocusId", "geneId")
         .agg(f.sum("weightedIntervalScore").alias(base_name))
-    ).persist()
+    )
 
     # Neighbourhood ratio within locus, using locus max as the denominator
     w = Window.partitionBy("studyLocusId")
@@ -307,13 +307,13 @@ def e2g_interval_feature_wide_logic(
         f.first("pp", ignorenulls=True).alias("pp"),
     )
 
-    base_df = (
+    base_df = persist_dataframe(
         per_variant_gene.withColumn(
             "weightedIntervalScore", f.col("maxScore") * f.col("pp")
         )
         .groupBy("studyLocusId", "geneId")
         .agg(f.sum("weightedIntervalScore").alias(base_name))
-    ).persist()
+    )
 
     w = Window.partitionBy("studyLocusId")
     with_max = base_df.withColumn("regional_max", f.max(base_name).over(w))
@@ -380,8 +380,8 @@ def get_or_make_e2g_wide(
             max_bins_per_interval=max_bins_per_interval,
             repartitions_variants=repartitions_variants,
             repartitions_intervals=repartitions_intervals,
-        ).persist()
-        feature_dependency[cache_key] = wide
+        )
+        feature_dependency[cache_key] = persist_dataframe(wide)
     return feature_dependency[cache_key]
 
 

--- a/src/gentropy/l2g.py
+++ b/src/gentropy/l2g.py
@@ -14,7 +14,7 @@ from xgboost import XGBClassifier
 
 from gentropy.common.schemas import compare_struct_schemas
 from gentropy.common.session import Session
-from gentropy.common.spark import calculate_harmonic_sum
+from gentropy.common.spark import calculate_harmonic_sum, persist_dataframe
 from gentropy.dataset.colocalisation import Colocalisation
 from gentropy.dataset.intervals import Intervals
 from gentropy.dataset.l2g_feature_matrix import L2GFeatureMatrix
@@ -237,16 +237,22 @@ class LocusToGeneTrainTestSplitStep:
         to_unpersist = []
 
         if predefined_test_parquet_path:
-            predefined_test_sdf = session.spark.read.parquet(predefined_test_parquet_path).persist()
+            predefined_test_sdf = persist_dataframe(
+                session.spark.read.parquet(predefined_test_parquet_path)
+            )
             to_unpersist.append(predefined_test_sdf)
 
             n_original_total: int = annotated_fm._df.count()
             n_original_test: int = predefined_test_sdf.count()
 
             # Positive gene IDs from the predefined test set.
-            test_positive_genes_sdf = predefined_test_sdf.filter(
-                f.col("goldStandardSet").isin([1, "positive"])
-            ).select("geneId").distinct()
+            test_positive_genes_sdf = (
+                predefined_test_sdf.filter(
+                    f.col("goldStandardSet").isin([1, "positive"])
+                )
+                .select("geneId")
+                .distinct()
+            )
 
             # studyLocusIds in annotated_fm that contain at least one test-positive gene.
             # The goldStandardSet label in annotated_fm is intentionally NOT checked here:
@@ -270,15 +276,27 @@ class LocusToGeneTrainTestSplitStep:
             )
 
             # Apply label encoding in Spark (handles both string and already-encoded int values).
-            label_map = f.create_map(f.lit("negative"), f.lit(0), f.lit("positive"), f.lit(1))
-            train_sdf = train_sdf.withColumn(
-                "goldStandardSet",
-                f.coalesce(label_map[f.col("goldStandardSet")], f.col("goldStandardSet").cast("int")),
-            ).persist()
-            test_sdf = test_sdf.withColumn(
-                "goldStandardSet",
-                f.coalesce(label_map[f.col("goldStandardSet")], f.col("goldStandardSet").cast("int")),
-            ).persist()
+            label_map = f.create_map(
+                f.lit("negative"), f.lit(0), f.lit("positive"), f.lit(1)
+            )
+            train_sdf = persist_dataframe(
+                train_sdf.withColumn(
+                    "goldStandardSet",
+                    f.coalesce(
+                        label_map[f.col("goldStandardSet")],
+                        f.col("goldStandardSet").cast("int"),
+                    ),
+                )
+            )
+            test_sdf = persist_dataframe(
+                test_sdf.withColumn(
+                    "goldStandardSet",
+                    f.coalesce(
+                        label_map[f.col("goldStandardSet")],
+                        f.col("goldStandardSet").cast("int"),
+                    ),
+                )
+            )
             to_unpersist.extend([train_sdf, test_sdf])
 
             n_train: int = train_sdf.count()
@@ -361,7 +379,9 @@ class LocusToGeneTrainTestSplitStep:
                     _df=gold_standard_raw,
                     _schema=L2GGoldStandard.get_schema(),
                 )
-            case {"unexpected_columns": extra_columns} if "missing_mandatory_columns" not in schema_issues:
+            case {"unexpected_columns": extra_columns} if (
+                "missing_mandatory_columns" not in schema_issues
+            ):
                 return L2GGoldStandard(
                     _df=gold_standard_raw.drop(*extra_columns),
                     _schema=L2GGoldStandard.get_schema(),
@@ -383,9 +403,13 @@ class LocusToGeneTrainTestSplitStep:
                 ],
             }:
                 if gene_interactions_path is None:
-                    raise ValueError("Interactions are required for parsing OTG curation.")
+                    raise ValueError(
+                        "Interactions are required for parsing OTG curation."
+                    )
                 if variant_index_path is None:
-                    raise ValueError("Variant Index is required for parsing OTG curation.")
+                    raise ValueError(
+                        "Variant Index is required for parsing OTG curation."
+                    )
                 interactions = session.load_data(
                     gene_interactions_path, "parquet", recursiveFileLookup=True
                 )
@@ -437,7 +461,9 @@ class LocusToGeneTrainTestSplitStep:
         }
         if "traitFromSourceMappedId" in df.columns:
             stats["n_unique_positive_gene_disease_pairs"] = int(
-                positive[["geneId", "traitFromSourceMappedId"]].drop_duplicates().shape[0]
+                positive[["geneId", "traitFromSourceMappedId"]]
+                .drop_duplicates()
+                .shape[0]
             )
         return stats
 
@@ -456,7 +482,9 @@ class LocusToGeneTrainTestSplitStep:
         """
         from pathlib import Path
 
-        stats_path = split_stats_path or train_parquet_path.rstrip("/") + "_split_stats.json"
+        stats_path = (
+            split_stats_path or train_parquet_path.rstrip("/") + "_split_stats.json"
+        )
         if not stats_path.startswith("gs://"):
             Path(stats_path).parent.mkdir(parents=True, exist_ok=True)
         with pd.io.common.get_handle(stats_path, mode="wt") as ioargs:
@@ -672,13 +700,19 @@ class LocusToGeneStep:
 
         # Load presplit data produced by LocusToGeneTrainTestSplitStep.
         # Persist so toPandas() (for XGBoost) and the union (for HF Hub metadata) share the cache.
-        train_sdf = self.session.spark.read.parquet(self.train_parquet_path).persist()
-        test_sdf = self.session.spark.read.parquet(self.test_parquet_path).persist()
+        train_sdf = persist_dataframe(
+            self.session.spark.read.parquet(self.train_parquet_path)
+        )
+        test_sdf = persist_dataframe(
+            self.session.spark.read.parquet(self.test_parquet_path)
+        )
 
         # Reconstruct L2GFeatureMatrix for model metadata (column order, HF Hub upload).
         # Labels are decoded back to strings because export_to_hugging_face_hub calls
         # generate_train_test_split, which expects string-encoded labels.
-        label_map = f.create_map(f.lit(0), f.lit("negative"), f.lit(1), f.lit("positive"))
+        label_map = f.create_map(
+            f.lit(0), f.lit("negative"), f.lit(1), f.lit("positive")
+        )
         feature_matrix = L2GFeatureMatrix(
             _df=train_sdf.union(test_sdf).withColumn(
                 "goldStandardSet",
@@ -908,9 +942,7 @@ class LocusToGeneModelTuningStep:
             train_pd[effective_features].apply(pd.to_numeric).to_numpy()
         )
         y_train: np.ndarray = train_pd[label_col].apply(pd.to_numeric).to_numpy()
-        x_test: np.ndarray = (
-            test_pd[effective_features].apply(pd.to_numeric).to_numpy()
-        )
+        x_test: np.ndarray = test_pd[effective_features].apply(pd.to_numeric).to_numpy()
         y_test: np.ndarray = test_pd[label_col].apply(pd.to_numeric).to_numpy()
 
         trainer.train_df = train_pd

--- a/tests/gentropy/common/test_spark_helpers.py
+++ b/tests/gentropy/common/test_spark_helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from pyspark.sql import Column, SparkSession
 from pyspark.sql import functions as f
@@ -10,6 +12,7 @@ from pyspark.sql import types as t
 from gentropy.common.spark import (
     enforce_schema,
     order_array_of_structs_by_field,
+    persist_dataframe,
 )
 
 
@@ -153,3 +156,31 @@ class TestEnforceSchema:
             "struct_6",
         ]:
             assert self.test_dataset.schema[column].dataType == self.EXPECTED_SCHEMA
+
+
+def test_persist_dataframe(spark: SparkSession) -> None:
+    """Test that persist_dataframe marks a dataframe for caching."""
+    df = spark.createDataFrame([(1,)], "a int")
+    try:
+        assert persist_dataframe(df).is_cached
+    finally:
+        df.unpersist()
+
+
+def test_persist_dataframe_falls_back_to_cache(spark: SparkSession) -> None:
+    """Test the fallback taken where persist cannot build a Java StorageLevel.
+
+    On some Spark distributions - Dataproc image 2.2 among them - py4j cannot reach the
+    `private[spark]` StorageLevel constructor, so `persist` raises where `cache`, which calls
+    the JVM directly, succeeds.
+    """
+    df = spark.createDataFrame([(1,)], "a int")
+    failure = Exception(
+        "py4j.Py4JException: Constructor org.apache.spark.storage.StorageLevel("
+        "[Boolean, Boolean, Boolean, Boolean, Integer]) does not exist"
+    )
+    try:
+        with patch.object(type(df), "persist", side_effect=failure):
+            assert persist_dataframe(df).is_cached
+    finally:
+        df.unpersist()


### PR DESCRIPTION
`DataFrame.persist()` fails on Dataproc image 2.2, which is what the gentropy clusters run:

```
py4j.Py4JException: Constructor org.apache.spark.storage.StorageLevel(
  [Boolean, Boolean, Boolean, Boolean, Integer]) does not exist
```

`persist` builds the Java `StorageLevel` from Python, and py4j cannot resolve that constructor here because it is `private[spark]` in Scala. Any step that persists therefore dies.

**Not a version skew.** Aligning the pyspark client to the cluster's Spark version (3.5.1 → 3.5.3) changes nothing. Unsetting `SPARK_HOME` to use pyspark's bundled jars is also not a way out: those jars lack the GCS connector, so all `gs://` I/O dies instead.

## Fix

`DataFrame.cache()` calls `_jdf.cache()` straight on the JVM and never builds a `StorageLevel`, so it works where `persist` does not — at the same storage level a no-argument `persist` asks for. Every gentropy caller persists at the default level, so this is an equivalent call rather than a downgrade.

New `common.spark.persist_dataframe` tries `persist` first and falls back to `cache` with a warning, making it a no-op wherever `persist` already works. Routed through it:

- `Dataset.persist`
- `L2GFeatureMatrix.persist`
- the bare `DataFrame.persist()` calls in `l2g.py` and `l2g_features/intervals.py`

The two `Dataset` methods cover most call sites in the codebase, since gentropy overwhelmingly persists `Dataset`s rather than raw dataframes.

## What is deliberately left out

Bare `DataFrame.persist()` calls outside the L2G paths — in `datasource/`, `study_index.py`, `study_locus.py`, `constraint_set.py` and others. They are in code this was not exercised against, and each needs its own check that the receiver really is a `DataFrame` rather than a `Dataset` whose `.persist` is already fixed. The helper is there for whoever picks them up.

Worth saying plainly: this works around an environment defect rather than curing it. If someone knows a Spark or py4j configuration that makes the constructor reachable on Dataproc 2.2, that would be the better fix and this PR should be closed in its favour. I could not find one.

## Tests

- `test_persist_dataframe` — the normal path still marks the dataframe cached.
- `test_persist_dataframe_falls_back_to_cache` — patches `persist` to raise the exact Dataproc error and asserts the dataframe still ends up cached.
- A doctest on the helper.

## Note on the diff

`l2g.py` carries some incidental reformatting: the file had lines the repo's own `ruff format` hook rewrites, and the hook reformats any file a commit touches. No behaviour changes in those hunks.

## Provenance

Hit while running the L2G feature matrix and training steps on Dataproc. Two other pre-existing defects surfaced in the same run and are in separate PRs: average precision computed from hard predictions (#1283), and `LocusToGeneModel.load_from_disk` mangling `gs://` paths (#1284).

🤖 Generated with [Claude Code](https://claude.com/claude-code)