### PR TITLE
feat(study locus): flag credible sets replicated in an independent study

### DIFF
--- a/src/gentropy/dataset/l2g_features/other.py
+++ b/src/gentropy/dataset/l2g_features/other.py
@@ -336,6 +336,10 @@ class CredibleSetConfidenceFeature(L2GFeature):
         """
         return (
             f.when(
+                f.col("confidence") == CredibleSetConfidenceClasses.REPLICATED.value,
+                f.lit(1.0),
+            )
+            .when(
                 f.col("confidence")
                 == CredibleSetConfidenceClasses.FINEMAPPED_IN_SAMPLE_LD.value,
                 f.lit(1.0),

--- a/src/gentropy/dataset/l2g_features/other.py
+++ b/src/gentropy/dataset/l2g_features/other.py
@@ -346,11 +346,6 @@ class CredibleSetConfidenceFeature(L2GFeature):
             )
             .when(
                 f.col("confidence")
-                == CredibleSetConfidenceClasses.REPLICATED_TOP_HIT.value,
-                f.lit(0.75),
-            )
-            .when(
-                f.col("confidence")
                 == CredibleSetConfidenceClasses.FINEMAPPED_OUT_OF_SAMPLE_LD.value,
                 f.lit(0.75),
             )

--- a/src/gentropy/dataset/l2g_features/other.py
+++ b/src/gentropy/dataset/l2g_features/other.py
@@ -346,6 +346,11 @@ class CredibleSetConfidenceFeature(L2GFeature):
             )
             .when(
                 f.col("confidence")
+                == CredibleSetConfidenceClasses.REPLICATED_TOP_HIT.value,
+                f.lit(0.75),
+            )
+            .when(
+                f.col("confidence")
                 == CredibleSetConfidenceClasses.FINEMAPPED_OUT_OF_SAMPLE_LD.value,
                 f.lit(0.75),
             )

--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -418,6 +418,20 @@ class StudyLocus(Dataset):
             _schema=StudyLocus.get_schema(),
         )
 
+    @staticmethod
+    def can_assess_replication(study_index: StudyIndex) -> bool:
+        """Whether credible set replication can be assessed against the given study index.
+
+        Args:
+            study_index (StudyIndex): Study index to test for the annotation `qc_replication` needs.
+
+        Returns:
+            bool: True if the study index carries both the disease and the gene annotation.
+        """
+        return all(
+            column in study_index.df.columns for column in ["diseaseIds", "geneId"]
+        )
+
     @qc_test
     def qc_replication(self: StudyLocus, study_index: StudyIndex) -> StudyLocus:
         """Flagging credible sets whose lead variant is not replicated in an independent study.
@@ -435,79 +449,81 @@ class StudyLocus(Dataset):
         study and the lead variant, so two credible sets of the same study sharing a lead variant
         are duplicates rather than independent evidence.
 
+        Both the disease and the gene annotation are needed. With only one of them the credible
+        sets of the other study type could not be assessed at all, yet would be indistinguishable
+        from replicated ones once the flag is written, so the check is a no-op on a study index
+        missing either.
+
         Args:
             study_index (StudyIndex): Study index providing disease, gene and study annotation.
 
         Returns:
             StudyLocus: Updated study locus with quality control flags.
         """
-        # The columns bringing the disease/gene annotation are all optional in the study index,
-        # so the check is only as strict as the available annotation:
+        if not self.can_assess_replication(study_index):
+            return self
+
+        # Two GWAS studies reporting the same cohorts, the same publication and the same LD
+        # population structure are the same evidence twice over. All three columns are optional;
+        # with none of them available the studies themselves are the closest available proxy for
+        # independent evidence:
         gwas_independence_columns = [
             column
             for column in ["cohorts", "pubmedId", "ldPopulationStructure"]
             if column in study_index.df.columns
-        ]
-        annotation_columns = [
-            column
-            for column in ["diseaseIds", "geneId"]
-            if column in study_index.df.columns
-        ]
+        ] or ["studyId"]
 
         loci = self.df.select("studyLocusId", "studyId", "variantId").join(
             study_index.df.select(
-                "studyId", "studyType", *annotation_columns, *gwas_independence_columns
+                "studyId",
+                "studyType",
+                "diseaseIds",
+                "geneId",
+                *[
+                    column
+                    for column in gwas_independence_columns
+                    if column != "studyId"
+                ],
             ),
             on="studyId",
             how="left",
         )
 
-        replicated_loci = None
+        # Exploding the diseases drops GWAS credible sets without disease annotation:
+        gwas = loci.filter(f.col("studyType") == "gwas").withColumn(
+            "diseaseId", f.explode("diseaseIds")
+        )
+        replicated_gwas_pairs = (
+            gwas.select("variantId", "diseaseId", *gwas_independence_columns)
+            .distinct()
+            .groupBy("variantId", "diseaseId")
+            .agg(f.count("*").alias("studyCount"))
+            .filter(f.col("studyCount") >= 2)
+            .select("variantId", "diseaseId")
+        )
+        replicated_gwas_loci = gwas.join(
+            replicated_gwas_pairs, on=["variantId", "diseaseId"], how="inner"
+        ).select("studyLocusId")
 
-        if "diseaseIds" in annotation_columns:
-            # Exploding the diseases drops GWAS credible sets without disease annotation:
-            gwas = loci.filter(f.col("studyType") == "gwas").withColumn(
-                "diseaseId", f.explode("diseaseIds")
-            )
-            replicated_gwas_pairs = (
-                gwas.select("variantId", "diseaseId", *gwas_independence_columns)
-                .distinct()
-                .groupBy("variantId", "diseaseId")
-                .agg(f.count("*").alias("studyCount"))
-                .filter(f.col("studyCount") >= 2)
-                .select("variantId", "diseaseId")
-            )
-            replicated_loci = gwas.join(
-                replicated_gwas_pairs, on=["variantId", "diseaseId"], how="inner"
-            ).select("studyLocusId")
+        molqtl = loci.filter(
+            (f.col("studyType") != "gwas") & f.col("geneId").isNotNull()
+        )
+        replicated_molqtl_pairs = (
+            molqtl.select("studyId", "variantId", "geneId")
+            .distinct()
+            .groupBy("variantId", "geneId")
+            .agg(f.count("*").alias("studyCount"))
+            .filter(f.col("studyCount") >= 2)
+            .select("variantId", "geneId")
+        )
+        replicated_molqtl_loci = molqtl.join(
+            replicated_molqtl_pairs, on=["variantId", "geneId"], how="inner"
+        ).select("studyLocusId")
 
-        if "geneId" in annotation_columns:
-            molqtl = loci.filter(
-                (f.col("studyType") != "gwas") & f.col("geneId").isNotNull()
-            )
-            replicated_molqtl_pairs = (
-                molqtl.select("studyId", "variantId", "geneId")
-                .distinct()
-                .groupBy("variantId", "geneId")
-                .agg(f.count("*").alias("studyCount"))
-                .filter(f.col("studyCount") >= 2)
-                .select("variantId", "geneId")
-            )
-            replicated_molqtl_loci = molqtl.join(
-                replicated_molqtl_pairs, on=["variantId", "geneId"], how="inner"
-            ).select("studyLocusId")
-            replicated_loci = (
-                replicated_molqtl_loci
-                if replicated_loci is None
-                else replicated_loci.unionByName(replicated_molqtl_loci)
-            )
-
-        # Without any annotation to replicate on, no credible set can be assessed:
-        if replicated_loci is None:
-            return self
-
-        replicated_loci = replicated_loci.distinct().withColumn(
-            "isReplicated", f.lit(True)
+        replicated_loci = (
+            replicated_gwas_loci.unionByName(replicated_molqtl_loci)
+            .distinct()
+            .withColumn("isReplicated", f.lit(True))
         )
 
         return StudyLocus(

--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -45,7 +45,6 @@ class CredibleSetConfidenceClasses(Enum):
     Attributes:
         REPLICATED (str): Credible set whose lead variant is replicated in an independent study
         FINEMAPPED_IN_SAMPLE_LD (str): SuSiE fine-mapped credible set with in-sample LD
-        REPLICATED_TOP_HIT (str): Replicated credible set that comes from a curated top hit
         FINEMAPPED_OUT_OF_SAMPLE_LD (str): SuSiE fine-mapped credible set with out-of-sample LD
         PICSED_SUMMARY_STATS (str): PICS fine-mapped credible set extracted from summary statistics
         PICSED_TOP_HIT (str): PICS fine-mapped credible set based on reported top hit
@@ -54,7 +53,6 @@ class CredibleSetConfidenceClasses(Enum):
 
     REPLICATED = "Replicated credible set"
     FINEMAPPED_IN_SAMPLE_LD = "SuSiE fine-mapped credible set with in-sample LD"
-    REPLICATED_TOP_HIT = "Replicated credible set from curated top hit"
     FINEMAPPED_OUT_OF_SAMPLE_LD = "SuSiE fine-mapped credible set with out-of-sample LD"
     PICSED_SUMMARY_STATS = (
         "PICS fine-mapped credible set extracted from summary statistics"
@@ -1581,9 +1579,8 @@ class StudyLocus(Dataset):
             return self
 
         # Credible sets replicated in an independent study are the most trustworthy ones,
-        # regardless of how they were fine-mapped, with the exception of curated top hits:
-        # replication does not make up for the locus never having been fine-mapped. Everything
-        # else falls through to the method-based classification below:
+        # regardless of how they were fine-mapped. Everything else falls through to the
+        # method-based classification below:
         replication_condition = (
             ~f.array_contains(
                 f.col("qualityControls"),
@@ -1597,13 +1594,6 @@ class StudyLocus(Dataset):
         df = self.df.withColumn(
             "confidence",
             f.when(
-                replication_condition
-                & f.array_contains(
-                    f.col("qualityControls"), StudyLocusQualityCheck.TOP_HIT.value
-                ),
-                CredibleSetConfidenceClasses.REPLICATED_TOP_HIT.value,
-            )
-            .when(
                 replication_condition,
                 CredibleSetConfidenceClasses.REPLICATED.value,
             )

--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -86,6 +86,7 @@ class StudyLocusQualityCheck(Enum):
         OUT_OF_SAMPLE_LD (str): Study locus finemapped without in-sample LD reference
         INVALID_CHROMOSOME (str): Chromosome not in 1:22, X, Y, XY or MT
         TOP_HIT_AND_SUMMARY_STATS (str): Curated top hit is flagged because summary statistics are available for study
+        NOT_REPLICATED (str): Lead variant of the credible set is not replicated in an independent study of the same disease or gene
     """
 
     SUBSIGNIFICANT_FLAG = "Subsignificant p-value"
@@ -119,6 +120,7 @@ class StudyLocusQualityCheck(Enum):
     TOP_HIT_AND_SUMMARY_STATS = (
         "Curated top hit is flagged because summary statistics are available for study"
     )
+    NOT_REPLICATED = "Lead variant is not replicated in independent study"
 
 
 class CredibleInterval(Enum):
@@ -405,11 +407,121 @@ class StudyLocus(Dataset):
                 "qualityControls",
                 self.update_quality_flag(
                     f.col("qualityControls"),
-                    self.flag_duplicates(f.col("studyLocusId"), [f.size("locus").asc()]),
+                    self.flag_duplicates(
+                        f.col("studyLocusId"), [f.size("locus").asc()]
+                    ),
                     StudyLocusQualityCheck.DUPLICATED_STUDYLOCUS_ID,
                 ),
             ),
             _schema=StudyLocus.get_schema(),
+        )
+
+    @qc_test
+    def qc_replication(self: StudyLocus, study_index: StudyIndex) -> StudyLocus:
+        """Flagging credible sets whose lead variant is not replicated in an independent study.
+
+        A GWAS credible set is considered replicated if its lead variant is associated with the
+        same disease in at least two independent studies, a molQTL credible set if its lead
+        variant is associated with the same gene in at least two studies.
+
+        Two GWAS studies are not independent if they report the same cohorts, the same publication
+        and the same LD population structure, so studies agreeing on all three are collapsed
+        before counting. GWAS studies with no disease annotation and molQTL studies with no
+        measured gene can never be replicated and are therefore always flagged.
+
+        On the molQTL side the count is over distinct studies: `studyLocusId` is a hash of the
+        study and the lead variant, so two credible sets of the same study sharing a lead variant
+        are duplicates rather than independent evidence.
+
+        Args:
+            study_index (StudyIndex): Study index providing disease, gene and study annotation.
+
+        Returns:
+            StudyLocus: Updated study locus with quality control flags.
+        """
+        # The columns bringing the disease/gene annotation are all optional in the study index,
+        # so the check is only as strict as the available annotation:
+        gwas_independence_columns = [
+            column
+            for column in ["cohorts", "pubmedId", "ldPopulationStructure"]
+            if column in study_index.df.columns
+        ]
+        annotation_columns = [
+            column
+            for column in ["diseaseIds", "geneId"]
+            if column in study_index.df.columns
+        ]
+
+        loci = self.df.select("studyLocusId", "studyId", "variantId").join(
+            study_index.df.select(
+                "studyId", "studyType", *annotation_columns, *gwas_independence_columns
+            ),
+            on="studyId",
+            how="left",
+        )
+
+        replicated_loci = None
+
+        if "diseaseIds" in annotation_columns:
+            # Exploding the diseases drops GWAS credible sets without disease annotation:
+            gwas = loci.filter(f.col("studyType") == "gwas").withColumn(
+                "diseaseId", f.explode("diseaseIds")
+            )
+            replicated_gwas_pairs = (
+                gwas.select("variantId", "diseaseId", *gwas_independence_columns)
+                .distinct()
+                .groupBy("variantId", "diseaseId")
+                .agg(f.count("*").alias("studyCount"))
+                .filter(f.col("studyCount") >= 2)
+                .select("variantId", "diseaseId")
+            )
+            replicated_loci = gwas.join(
+                replicated_gwas_pairs, on=["variantId", "diseaseId"], how="inner"
+            ).select("studyLocusId")
+
+        if "geneId" in annotation_columns:
+            molqtl = loci.filter(
+                (f.col("studyType") != "gwas") & f.col("geneId").isNotNull()
+            )
+            replicated_molqtl_pairs = (
+                molqtl.select("studyId", "variantId", "geneId")
+                .distinct()
+                .groupBy("variantId", "geneId")
+                .agg(f.count("*").alias("studyCount"))
+                .filter(f.col("studyCount") >= 2)
+                .select("variantId", "geneId")
+            )
+            replicated_molqtl_loci = molqtl.join(
+                replicated_molqtl_pairs, on=["variantId", "geneId"], how="inner"
+            ).select("studyLocusId")
+            replicated_loci = (
+                replicated_molqtl_loci
+                if replicated_loci is None
+                else replicated_loci.unionByName(replicated_molqtl_loci)
+            )
+
+        # Without any annotation to replicate on, no credible set can be assessed:
+        if replicated_loci is None:
+            return self
+
+        replicated_loci = replicated_loci.distinct().withColumn(
+            "isReplicated", f.lit(True)
+        )
+
+        return StudyLocus(
+            _df=(
+                self.df.join(replicated_loci, on="studyLocusId", how="left")
+                .withColumn(
+                    "qualityControls",
+                    self.update_quality_flag(
+                        f.col("qualityControls"),
+                        f.col("isReplicated").isNull(),
+                        StudyLocusQualityCheck.NOT_REPLICATED,
+                    ),
+                )
+                .drop("isReplicated")
+            ),
+            _schema=self.get_schema(),
         )
 
     @staticmethod

--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -45,6 +45,7 @@ class CredibleSetConfidenceClasses(Enum):
     Attributes:
         REPLICATED (str): Credible set whose lead variant is replicated in an independent study
         FINEMAPPED_IN_SAMPLE_LD (str): SuSiE fine-mapped credible set with in-sample LD
+        REPLICATED_TOP_HIT (str): Replicated credible set that comes from a curated top hit
         FINEMAPPED_OUT_OF_SAMPLE_LD (str): SuSiE fine-mapped credible set with out-of-sample LD
         PICSED_SUMMARY_STATS (str): PICS fine-mapped credible set extracted from summary statistics
         PICSED_TOP_HIT (str): PICS fine-mapped credible set based on reported top hit
@@ -53,6 +54,7 @@ class CredibleSetConfidenceClasses(Enum):
 
     REPLICATED = "Replicated credible set"
     FINEMAPPED_IN_SAMPLE_LD = "SuSiE fine-mapped credible set with in-sample LD"
+    REPLICATED_TOP_HIT = "Replicated credible set from curated top hit"
     FINEMAPPED_OUT_OF_SAMPLE_LD = "SuSiE fine-mapped credible set with out-of-sample LD"
     PICSED_SUMMARY_STATS = (
         "PICS fine-mapped credible set extracted from summary statistics"
@@ -1579,8 +1581,9 @@ class StudyLocus(Dataset):
             return self
 
         # Credible sets replicated in an independent study are the most trustworthy ones,
-        # regardless of how they were fine-mapped. Everything else falls through to the
-        # method-based classification below:
+        # regardless of how they were fine-mapped, with the exception of curated top hits:
+        # replication does not make up for the locus never having been fine-mapped. Everything
+        # else falls through to the method-based classification below:
         replication_condition = (
             ~f.array_contains(
                 f.col("qualityControls"),
@@ -1594,6 +1597,13 @@ class StudyLocus(Dataset):
         df = self.df.withColumn(
             "confidence",
             f.when(
+                replication_condition
+                & f.array_contains(
+                    f.col("qualityControls"), StudyLocusQualityCheck.TOP_HIT.value
+                ),
+                CredibleSetConfidenceClasses.REPLICATED_TOP_HIT.value,
+            )
+            .when(
                 replication_condition,
                 CredibleSetConfidenceClasses.REPLICATED.value,
             )

--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -409,27 +409,11 @@ class StudyLocus(Dataset):
                 "qualityControls",
                 self.update_quality_flag(
                     f.col("qualityControls"),
-                    self.flag_duplicates(
-                        f.col("studyLocusId"), [f.size("locus").asc()]
-                    ),
+                    self.flag_duplicates(f.col("studyLocusId"), [f.size("locus").asc()]),
                     StudyLocusQualityCheck.DUPLICATED_STUDYLOCUS_ID,
                 ),
             ),
             _schema=StudyLocus.get_schema(),
-        )
-
-    @staticmethod
-    def can_assess_replication(study_index: StudyIndex) -> bool:
-        """Whether credible set replication can be assessed against the given study index.
-
-        Args:
-            study_index (StudyIndex): Study index to test for the annotation `qc_replication` needs.
-
-        Returns:
-            bool: True if the study index carries both the disease and the gene annotation.
-        """
-        return all(
-            column in study_index.df.columns for column in ["diseaseIds", "geneId"]
         )
 
     @qc_test
@@ -440,19 +424,14 @@ class StudyLocus(Dataset):
         same disease in at least two independent studies, a molQTL credible set if its lead
         variant is associated with the same gene in at least two studies.
 
-        Two GWAS studies are not independent if they report the same cohorts, the same publication
-        and the same LD population structure, so studies agreeing on all three are collapsed
-        before counting. GWAS studies with no disease annotation and molQTL studies with no
-        measured gene can never be replicated and are therefore always flagged.
+        Two GWAS studies reporting the same cohorts, the same publication and the same LD
+        population structure are the same evidence twice over, so they are collapsed before
+        counting. GWAS studies with no disease annotation and molQTL studies with no measured
+        gene can never be replicated and are therefore always flagged.
 
-        On the molQTL side the count is over distinct studies: `studyLocusId` is a hash of the
-        study and the lead variant, so two credible sets of the same study sharing a lead variant
-        are duplicates rather than independent evidence.
-
-        Both the disease and the gene annotation are needed. With only one of them the credible
-        sets of the other study type could not be assessed at all, yet would be indistinguishable
-        from replicated ones once the flag is written, so the check is a no-op on a study index
-        missing either.
+        Run this at the very end of validation, against a validated study index and the credible
+        sets that passed every other check: a credible set removed by an earlier flag is not
+        evidence of replication, and duplicated credible sets of one study would count as two.
 
         Args:
             study_index (StudyIndex): Study index providing disease, gene and study annotation.
@@ -460,30 +439,15 @@ class StudyLocus(Dataset):
         Returns:
             StudyLocus: Updated study locus with quality control flags.
         """
-        if not self.can_assess_replication(study_index):
-            return self
-
-        # Two GWAS studies reporting the same cohorts, the same publication and the same LD
-        # population structure are the same evidence twice over. All three columns are optional;
-        # with none of them available the studies themselves are the closest available proxy for
-        # independent evidence:
-        gwas_independence_columns = [
-            column
-            for column in ["cohorts", "pubmedId", "ldPopulationStructure"]
-            if column in study_index.df.columns
-        ] or ["studyId"]
-
         loci = self.df.select("studyLocusId", "studyId", "variantId").join(
             study_index.df.select(
                 "studyId",
                 "studyType",
                 "diseaseIds",
                 "geneId",
-                *[
-                    column
-                    for column in gwas_independence_columns
-                    if column != "studyId"
-                ],
+                "cohorts",
+                "pubmedId",
+                "ldPopulationStructure",
             ),
             on="studyId",
             how="left",
@@ -493,31 +457,27 @@ class StudyLocus(Dataset):
         gwas = loci.filter(f.col("studyType") == "gwas").withColumn(
             "diseaseId", f.explode("diseaseIds")
         )
-        replicated_gwas_pairs = (
-            gwas.select("variantId", "diseaseId", *gwas_independence_columns)
+        replicated_gwas_loci = gwas.join(
+            gwas.select(
+                "variantId",
+                "diseaseId",
+                "cohorts",
+                "pubmedId",
+                "ldPopulationStructure",
+            )
             .distinct()
             .groupBy("variantId", "diseaseId")
-            .agg(f.count("*").alias("studyCount"))
-            .filter(f.col("studyCount") >= 2)
-            .select("variantId", "diseaseId")
-        )
-        replicated_gwas_loci = gwas.join(
-            replicated_gwas_pairs, on=["variantId", "diseaseId"], how="inner"
+            .count()
+            .filter(f.col("count") >= 2),
+            on=["variantId", "diseaseId"],
+            how="inner",
         ).select("studyLocusId")
 
-        molqtl = loci.filter(
-            (f.col("studyType") != "gwas") & f.col("geneId").isNotNull()
-        )
-        replicated_molqtl_pairs = (
-            molqtl.select("studyId", "variantId", "geneId")
-            .distinct()
-            .groupBy("variantId", "geneId")
-            .agg(f.count("*").alias("studyCount"))
-            .filter(f.col("studyCount") >= 2)
-            .select("variantId", "geneId")
-        )
+        molqtl = loci.filter(f.col("studyType") != "gwas")
         replicated_molqtl_loci = molqtl.join(
-            replicated_molqtl_pairs, on=["variantId", "geneId"], how="inner"
+            molqtl.groupBy("variantId", "geneId").count().filter(f.col("count") >= 2),
+            on=["variantId", "geneId"],
+            how="inner",
         ).select("studyLocusId")
 
         replicated_loci = (

--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -43,6 +43,7 @@ class CredibleSetConfidenceClasses(Enum):
     List of confidence classes, from the highest to the lowest confidence level.
 
     Attributes:
+        REPLICATED (str): Credible set whose lead variant is replicated in an independent study
         FINEMAPPED_IN_SAMPLE_LD (str): SuSiE fine-mapped credible set with in-sample LD
         FINEMAPPED_OUT_OF_SAMPLE_LD (str): SuSiE fine-mapped credible set with out-of-sample LD
         PICSED_SUMMARY_STATS (str): PICS fine-mapped credible set extracted from summary statistics
@@ -50,6 +51,7 @@ class CredibleSetConfidenceClasses(Enum):
         UNKNOWN (str): Unknown confidence, for credible sets which did not fit any of the above categories
     """
 
+    REPLICATED = "Replicated credible set"
     FINEMAPPED_IN_SAMPLE_LD = "SuSiE fine-mapped credible set with in-sample LD"
     FINEMAPPED_OUT_OF_SAMPLE_LD = "SuSiE fine-mapped credible set with out-of-sample LD"
     PICSED_SUMMARY_STATS = (
@@ -1554,8 +1556,17 @@ class StudyLocus(Dataset):
 
         return WindowBasedClumping.clump(self, window_size)
 
-    def assign_confidence(self: StudyLocus) -> StudyLocus:
+    def assign_confidence(
+        self: StudyLocus, use_replication: bool = False
+    ) -> StudyLocus:
         """Assign confidence to study locus.
+
+        Args:
+            use_replication (bool): Whether replication is taken into account, in which case
+                credible sets replicated in an independent study get the highest confidence and
+                the rest are classified by fine-mapping method as usual. Only set this if
+                `qc_replication` has already been applied: replication is read from the absence
+                of the `NOT_REPLICATED` flag, which is also absent when the check never ran.
 
         Returns:
             StudyLocus: Study locus with confidence assigned.
@@ -1567,10 +1578,26 @@ class StudyLocus(Dataset):
         ):
             return self
 
+        # Credible sets replicated in an independent study are the most trustworthy ones,
+        # regardless of how they were fine-mapped. Everything else falls through to the
+        # method-based classification below:
+        replication_condition = (
+            ~f.array_contains(
+                f.col("qualityControls"),
+                StudyLocusQualityCheck.NOT_REPLICATED.value,
+            )
+            if use_replication
+            else f.lit(False)
+        )
+
         # Assign confidence based on the presence of quality controls
         df = self.df.withColumn(
             "confidence",
             f.when(
+                replication_condition,
+                CredibleSetConfidenceClasses.REPLICATED.value,
+            )
+            .when(
                 (
                     f.col("finemappingMethod").isin(
                         FinemappingMethod.SUSIE.value,

--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -60,6 +60,10 @@ class StudyLocusValidationStep:
             # after the 95% filter so that the smallest-credible-set rule sees the credible sets
             # themselves rather than the full set of tagging variants.
             .validate_unique_study_locus_id()
+            # Flagging credible sets whose lead variant is not replicated in an independent
+            # record. Runs after the duplicate check so that colliding credible sets of the
+            # same study cannot count as independent evidence.
+            .qc_replication(study_index)
             # Flagging credible sets with PIP > 1 or PIP < 0.95
             .qc_abnormal_pips(
                 sum_pips_lower_threshold=0.95,

--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -60,20 +60,13 @@ class StudyLocusValidationStep:
             # after the 95% filter so that the smallest-credible-set rule sees the credible sets
             # themselves rather than the full set of tagging variants.
             .validate_unique_study_locus_id()
-            # Flagging credible sets whose lead variant is not replicated in an independent
-            # record. Runs after the duplicate check so that colliding credible sets of the
-            # same study cannot count as independent evidence.
-            .qc_replication(study_index)
             # Flagging credible sets with PIP > 1 or PIP < 0.95
             .qc_abnormal_pips(
                 sum_pips_lower_threshold=0.95,
                 sum_pips_upper_threshold=1.0001,
             )
-            # Annotate credible set confidence, taking the replication flag raised above into
-            # account whenever the study index allowed the check to run:
-            .assign_confidence(
-                use_replication=StudyLocus.can_assess_replication(study_index)
-            )
+            # Annotate credible set confidence:
+            .assign_confidence()
             # Flagging trans qtls:
             .flag_trans_qtls(study_index, target_index, trans_qtl_threshold)
             .persist()  # we will need this for 2 types of outputs
@@ -81,9 +74,16 @@ class StudyLocusValidationStep:
 
         result = study_locus_with_qc.valid_rows(invalid_qc_reasons)
 
+        # Replication is assessed once every other check is done, on the credible sets that
+        # passed them: a credible set dropped by an earlier flag is not evidence of replication.
+        # The confidence is then re-assigned, this time taking replication into account.
+        valid_study_locus = result.valid.qc_replication(study_index).assign_confidence(
+            use_replication=True
+        )
+
         (
             # Valid study locus partitioned to simplify the finding of overlaps
-            result.valid.df.repartitionByRange(
+            valid_study_locus.df.repartitionByRange(
                 session.output_partitions,
                 "chromosome",
                 "position",

--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -69,9 +69,11 @@ class StudyLocusValidationStep:
                 sum_pips_lower_threshold=0.95,
                 sum_pips_upper_threshold=1.0001,
             )
-            # Annotate credible set confidence, taking the replication flag raised above
-            # into account:
-            .assign_confidence(use_replication=True)
+            # Annotate credible set confidence, taking the replication flag raised above into
+            # account whenever the study index allowed the check to run:
+            .assign_confidence(
+                use_replication=StudyLocus.can_assess_replication(study_index)
+            )
             # Flagging trans qtls:
             .flag_trans_qtls(study_index, target_index, trans_qtl_threshold)
             .persist()  # we will need this for 2 types of outputs

--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -69,8 +69,9 @@ class StudyLocusValidationStep:
                 sum_pips_lower_threshold=0.95,
                 sum_pips_upper_threshold=1.0001,
             )
-            # Annotate credible set confidence:
-            .assign_confidence()
+            # Annotate credible set confidence, taking the replication flag raised above
+            # into account:
+            .assign_confidence(use_replication=True)
             # Flagging trans qtls:
             .flag_trans_qtls(study_index, target_index, trans_qtl_threshold)
             .persist()  # we will need this for 2 types of outputs

--- a/tests/gentropy/dataset/test_study_locus.py
+++ b/tests/gentropy/dataset/test_study_locus.py
@@ -1272,6 +1272,136 @@ class TestStudyLocusDuplicationFlagging:
         assert retained[0]["locusSize"] == 1
 
 
+class TestStudyLocusReplicationFlagging:
+    """Collection of tests related to flagging credible sets without independent replication."""
+
+    STUDY_LOCUS_DATA = [
+        # Same lead variant and disease in two independent study records -> replicated:
+        ("1", "v1", "s1"),
+        ("2", "v1", "s2"),
+        # s3 reports the same cohorts, publication and LD structure as s1, so the two records
+        # are not independent evidence -> not replicated:
+        ("3", "v2", "s1"),
+        ("4", "v2", "s3"),
+        # GWAS study without disease annotation -> not replicated:
+        ("5", "v3", "s4"),
+        # Same lead variant and gene measured by two molQTL studies -> replicated:
+        ("6", "v4", "s5"),
+        ("7", "v4", "s6"),
+        # Only molQTL study measuring this gene at this variant -> not replicated:
+        ("8", "v4", "s7"),
+        # Two credible sets of the same molQTL study -> not replicated:
+        ("9", "v5", "s5"),
+        ("10", "v5", "s5"),
+        # molQTL study without measured gene -> not replicated:
+        ("11", "v6", "s8"),
+    ]
+
+    STUDY_LOCUS_SCHEMA = t.StructType(
+        [
+            t.StructField("studyLocusId", t.StringType(), False),
+            t.StructField("variantId", t.StringType(), False),
+            t.StructField("studyId", t.StringType(), False),
+        ]
+    )
+
+    STUDY_DATA = [
+        ("s1", "p1", "gwas", ["d1"], None, ["c1"], "pm1", [("nfe", 1.0)]),
+        ("s2", "p1", "gwas", ["d1"], None, ["c2"], "pm2", [("fin", 1.0)]),
+        ("s3", "p1", "gwas", ["d1"], None, ["c1"], "pm1", [("nfe", 1.0)]),
+        ("s4", "p1", "gwas", None, None, ["c3"], "pm3", [("nfe", 1.0)]),
+        ("s5", "p2", "eqtl", None, "g1", None, None, None),
+        ("s6", "p2", "eqtl", None, "g1", None, None, None),
+        ("s7", "p2", "eqtl", None, "g2", None, None, None),
+        ("s8", "p2", "eqtl", None, None, None, None, None),
+    ]
+
+    STUDY_SCHEMA = t.StructType(
+        [
+            t.StructField("studyId", t.StringType(), False),
+            t.StructField("projectId", t.StringType(), False),
+            t.StructField("studyType", t.StringType(), False),
+            t.StructField("diseaseIds", t.ArrayType(t.StringType()), True),
+            t.StructField("geneId", t.StringType(), True),
+            t.StructField("cohorts", t.ArrayType(t.StringType()), True),
+            t.StructField("pubmedId", t.StringType(), True),
+            t.StructField(
+                "ldPopulationStructure",
+                t.ArrayType(
+                    t.StructType(
+                        [
+                            t.StructField("ldPopulation", t.StringType(), True),
+                            t.StructField("relativeSampleSize", t.DoubleType(), True),
+                        ]
+                    )
+                ),
+                True,
+            ),
+        ]
+    )
+
+    @pytest.fixture(autouse=True)
+    def _setup(self: TestStudyLocusReplicationFlagging, spark: SparkSession) -> None:
+        """Setup study locus and study index for testing."""
+        self.study_locus = StudyLocus(
+            _df=spark.createDataFrame(
+                self.STUDY_LOCUS_DATA, schema=self.STUDY_LOCUS_SCHEMA
+            ).withColumn(
+                "qualityControls", f.array().cast(t.ArrayType(t.StringType()))
+            ),
+            _schema=StudyLocus.get_schema(),
+        )
+        self.study_index = StudyIndex(
+            _df=spark.createDataFrame(self.STUDY_DATA, schema=self.STUDY_SCHEMA),
+            _schema=StudyIndex.get_schema(),
+        )
+        self.validated = self.study_locus.qc_replication(self.study_index)
+
+    def test_replication_flag_type(
+        self: TestStudyLocusReplicationFlagging,
+    ) -> None:
+        """Test replication flagging return type."""
+        assert isinstance(self.validated, StudyLocus)
+
+    def test_replication_flag_no_data_loss(
+        self: TestStudyLocusReplicationFlagging,
+    ) -> None:
+        """Test replication flagging no data loss."""
+        assert self.validated.df.count() == self.study_locus.df.count()
+
+    def test_replication_flag_correctness(
+        self: TestStudyLocusReplicationFlagging,
+    ) -> None:
+        """Only the credible sets with independent replication are left unflagged."""
+        flagged = {
+            row["studyLocusId"]
+            for row in self.validated.df.filter(
+                f.array_contains(
+                    f.col("qualityControls"),
+                    StudyLocusQualityCheck.NOT_REPLICATED.value,
+                )
+            ).collect()
+        }
+
+        assert flagged == {"3", "4", "5", "8", "9", "10", "11"}
+
+    def test_replication_flag_without_annotation(
+        self: TestStudyLocusReplicationFlagging,
+    ) -> None:
+        """Without disease and gene annotation in the study index nothing can be assessed."""
+        unannotated = StudyIndex(
+            _df=self.study_index.df.drop("diseaseIds", "geneId"),
+            _schema=StudyIndex.get_schema(),
+        )
+
+        assert (
+            self.study_locus.qc_replication(unannotated)
+            .df.filter(f.size("qualityControls") > 0)
+            .count()
+            == 0
+        )
+
+
 class TestTransQtlFlagging:
     """Test flagging trans qtl credible sets."""
 

--- a/tests/gentropy/dataset/test_study_locus.py
+++ b/tests/gentropy/dataset/test_study_locus.py
@@ -1385,21 +1385,53 @@ class TestStudyLocusReplicationFlagging:
 
         assert flagged == {"3", "4", "5", "8", "9", "10", "11"}
 
-    def test_replication_flag_without_annotation(
-        self: TestStudyLocusReplicationFlagging,
+    @pytest.mark.parametrize(
+        "missing_columns",
+        [["diseaseIds", "geneId"], ["diseaseIds"], ["geneId"]],
+    )
+    def test_replication_flag_needs_both_annotations(
+        self: TestStudyLocusReplicationFlagging, missing_columns: list[str]
     ) -> None:
-        """Without disease and gene annotation in the study index nothing can be assessed."""
-        unannotated = StudyIndex(
-            _df=self.study_index.df.drop("diseaseIds", "geneId"),
+        """Partial annotation leaves one study type unassessable, so the check does not run."""
+        partial = StudyIndex(
+            _df=self.study_index.df.drop(*missing_columns),
             _schema=StudyIndex.get_schema(),
         )
 
+        assert not StudyLocus.can_assess_replication(partial)
         assert (
-            self.study_locus.qc_replication(unannotated)
+            self.study_locus.qc_replication(partial)
             .df.filter(f.size("qualityControls") > 0)
             .count()
             == 0
         )
+
+    def test_replication_without_independence_annotation(
+        self: TestStudyLocusReplicationFlagging,
+    ) -> None:
+        """Without cohorts, publication and LD structure, GWAS studies stand in for independence."""
+        no_independence_annotation = StudyIndex(
+            _df=self.study_index.df.drop(
+                "cohorts", "pubmedId", "ldPopulationStructure"
+            ),
+            _schema=StudyIndex.get_schema(),
+        )
+
+        flagged = {
+            row["studyLocusId"]
+            for row in self.study_locus.qc_replication(no_independence_annotation)
+            .df.filter(
+                f.array_contains(
+                    f.col("qualityControls"),
+                    StudyLocusQualityCheck.NOT_REPLICATED.value,
+                )
+            )
+            .collect()
+        }
+
+        # Credible sets 3 and 4 are now counted as replicated: s1 and s3 can no longer be told
+        # apart from two genuinely independent studies. Everything else is unchanged.
+        assert flagged == {"5", "8", "9", "10", "11"}
 
 
 class TestStudyLocusConfidenceWithReplication:

--- a/tests/gentropy/dataset/test_study_locus.py
+++ b/tests/gentropy/dataset/test_study_locus.py
@@ -1402,6 +1402,92 @@ class TestStudyLocusReplicationFlagging:
         )
 
 
+class TestStudyLocusConfidenceWithReplication:
+    """Testing how replication feeds into the credible set confidence assignment."""
+
+    STUDY_LOCUS_DATA = [
+        ("1", "v1", "s1", "SuSie", []),
+        ("2", "v2", "s1", "SuSie", [StudyLocusQualityCheck.NOT_REPLICATED.value]),
+        ("3", "v3", "s1", "PICS", [StudyLocusQualityCheck.TOP_HIT.value]),
+        (
+            "4",
+            "v4",
+            "s1",
+            "PICS",
+            [
+                StudyLocusQualityCheck.TOP_HIT.value,
+                StudyLocusQualityCheck.NOT_REPLICATED.value,
+            ],
+        ),
+        (
+            "5",
+            "v5",
+            "s1",
+            "SuSie",
+            [
+                StudyLocusQualityCheck.OUT_OF_SAMPLE_LD.value,
+                StudyLocusQualityCheck.NOT_REPLICATED.value,
+            ],
+        ),
+        ("6", "v6", "s1", "unknown", [StudyLocusQualityCheck.NOT_REPLICATED.value]),
+    ]
+
+    STUDY_LOCUS_SCHEMA = t.StructType(
+        [
+            t.StructField("studyLocusId", t.StringType(), False),
+            t.StructField("variantId", t.StringType(), False),
+            t.StructField("studyId", t.StringType(), False),
+            t.StructField("finemappingMethod", t.StringType(), False),
+            t.StructField("qualityControls", t.ArrayType(t.StringType()), False),
+        ]
+    )
+
+    @pytest.fixture(autouse=True)
+    def _setup(
+        self: TestStudyLocusConfidenceWithReplication, spark: SparkSession
+    ) -> None:
+        """Setup study locus for testing."""
+        self.study_locus = StudyLocus(
+            _df=spark.createDataFrame(
+                self.STUDY_LOCUS_DATA, schema=self.STUDY_LOCUS_SCHEMA
+            ),
+            _schema=StudyLocus.get_schema(),
+        )
+
+    def test_replicated_credible_sets_get_highest_confidence(
+        self: TestStudyLocusConfidenceWithReplication,
+    ) -> None:
+        """Replicated credible sets are the most confident ones, whatever the fine-mapping method."""
+        confidence = {
+            row["studyLocusId"]: row["confidence"]
+            for row in self.study_locus.assign_confidence(use_replication=True)
+            .df.select("studyLocusId", "confidence")
+            .collect()
+        }
+
+        assert confidence == {
+            "1": CredibleSetConfidenceClasses.REPLICATED.value,
+            "2": CredibleSetConfidenceClasses.FINEMAPPED_IN_SAMPLE_LD.value,
+            "3": CredibleSetConfidenceClasses.REPLICATED.value,
+            "4": CredibleSetConfidenceClasses.PICSED_TOP_HIT.value,
+            "5": CredibleSetConfidenceClasses.FINEMAPPED_OUT_OF_SAMPLE_LD.value,
+            "6": CredibleSetConfidenceClasses.UNKNOWN.value,
+        }
+
+    def test_replication_is_ignored_by_default(
+        self: TestStudyLocusConfidenceWithReplication,
+    ) -> None:
+        """Without `use_replication` the assignment is driven by the fine-mapping method alone."""
+        assert (
+            self.study_locus.assign_confidence()
+            .df.filter(
+                f.col("confidence") == CredibleSetConfidenceClasses.REPLICATED.value
+            )
+            .count()
+            == 0
+        )
+
+
 class TestTransQtlFlagging:
     """Test flagging trans qtl credible sets."""
 

--- a/tests/gentropy/dataset/test_study_locus.py
+++ b/tests/gentropy/dataset/test_study_locus.py
@@ -1290,11 +1290,8 @@ class TestStudyLocusReplicationFlagging:
         ("7", "v4", "s6"),
         # Only molQTL study measuring this gene at this variant -> not replicated:
         ("8", "v4", "s7"),
-        # Two credible sets of the same molQTL study -> not replicated:
-        ("9", "v5", "s5"),
-        ("10", "v5", "s5"),
         # molQTL study without measured gene -> not replicated:
-        ("11", "v6", "s8"),
+        ("9", "v5", "s8"),
     ]
 
     STUDY_LOCUS_SCHEMA = t.StructType(
@@ -1383,55 +1380,7 @@ class TestStudyLocusReplicationFlagging:
             ).collect()
         }
 
-        assert flagged == {"3", "4", "5", "8", "9", "10", "11"}
-
-    @pytest.mark.parametrize(
-        "missing_columns",
-        [["diseaseIds", "geneId"], ["diseaseIds"], ["geneId"]],
-    )
-    def test_replication_flag_needs_both_annotations(
-        self: TestStudyLocusReplicationFlagging, missing_columns: list[str]
-    ) -> None:
-        """Partial annotation leaves one study type unassessable, so the check does not run."""
-        partial = StudyIndex(
-            _df=self.study_index.df.drop(*missing_columns),
-            _schema=StudyIndex.get_schema(),
-        )
-
-        assert not StudyLocus.can_assess_replication(partial)
-        assert (
-            self.study_locus.qc_replication(partial)
-            .df.filter(f.size("qualityControls") > 0)
-            .count()
-            == 0
-        )
-
-    def test_replication_without_independence_annotation(
-        self: TestStudyLocusReplicationFlagging,
-    ) -> None:
-        """Without cohorts, publication and LD structure, GWAS studies stand in for independence."""
-        no_independence_annotation = StudyIndex(
-            _df=self.study_index.df.drop(
-                "cohorts", "pubmedId", "ldPopulationStructure"
-            ),
-            _schema=StudyIndex.get_schema(),
-        )
-
-        flagged = {
-            row["studyLocusId"]
-            for row in self.study_locus.qc_replication(no_independence_annotation)
-            .df.filter(
-                f.array_contains(
-                    f.col("qualityControls"),
-                    StudyLocusQualityCheck.NOT_REPLICATED.value,
-                )
-            )
-            .collect()
-        }
-
-        # Credible sets 3 and 4 are now counted as replicated: s1 and s3 can no longer be told
-        # apart from two genuinely independent studies. Everything else is unchanged.
-        assert flagged == {"5", "8", "9", "10", "11"}
+        assert flagged == {"3", "4", "5", "8", "9"}
 
 
 class TestStudyLocusConfidenceWithReplication:

--- a/tests/gentropy/dataset/test_study_locus.py
+++ b/tests/gentropy/dataset/test_study_locus.py
@@ -1430,6 +1430,7 @@ class TestStudyLocusConfidenceWithReplication:
             ],
         ),
         ("6", "v6", "s1", "unknown", [StudyLocusQualityCheck.NOT_REPLICATED.value]),
+        ("7", "v7", "s1", "PICS", []),
     ]
 
     STUDY_LOCUS_SCHEMA = t.StructType(
@@ -1457,7 +1458,7 @@ class TestStudyLocusConfidenceWithReplication:
     def test_replicated_credible_sets_get_highest_confidence(
         self: TestStudyLocusConfidenceWithReplication,
     ) -> None:
-        """Replicated credible sets are the most confident ones, whatever the fine-mapping method."""
+        """Replicated credible sets are the most confident ones, curated top hits excepted."""
         confidence = {
             row["studyLocusId"]: row["confidence"]
             for row in self.study_locus.assign_confidence(use_replication=True)
@@ -1468,10 +1469,11 @@ class TestStudyLocusConfidenceWithReplication:
         assert confidence == {
             "1": CredibleSetConfidenceClasses.REPLICATED.value,
             "2": CredibleSetConfidenceClasses.FINEMAPPED_IN_SAMPLE_LD.value,
-            "3": CredibleSetConfidenceClasses.REPLICATED.value,
+            "3": CredibleSetConfidenceClasses.REPLICATED_TOP_HIT.value,
             "4": CredibleSetConfidenceClasses.PICSED_TOP_HIT.value,
             "5": CredibleSetConfidenceClasses.FINEMAPPED_OUT_OF_SAMPLE_LD.value,
             "6": CredibleSetConfidenceClasses.UNKNOWN.value,
+            "7": CredibleSetConfidenceClasses.REPLICATED.value,
         }
 
     def test_replication_is_ignored_by_default(
@@ -1481,7 +1483,10 @@ class TestStudyLocusConfidenceWithReplication:
         assert (
             self.study_locus.assign_confidence()
             .df.filter(
-                f.col("confidence") == CredibleSetConfidenceClasses.REPLICATED.value
+                f.col("confidence").isin(
+                    CredibleSetConfidenceClasses.REPLICATED.value,
+                    CredibleSetConfidenceClasses.REPLICATED_TOP_HIT.value,
+                )
             )
             .count()
             == 0

--- a/tests/gentropy/dataset/test_study_locus.py
+++ b/tests/gentropy/dataset/test_study_locus.py
@@ -1430,7 +1430,6 @@ class TestStudyLocusConfidenceWithReplication:
             ],
         ),
         ("6", "v6", "s1", "unknown", [StudyLocusQualityCheck.NOT_REPLICATED.value]),
-        ("7", "v7", "s1", "PICS", []),
     ]
 
     STUDY_LOCUS_SCHEMA = t.StructType(
@@ -1458,7 +1457,7 @@ class TestStudyLocusConfidenceWithReplication:
     def test_replicated_credible_sets_get_highest_confidence(
         self: TestStudyLocusConfidenceWithReplication,
     ) -> None:
-        """Replicated credible sets are the most confident ones, curated top hits excepted."""
+        """Replicated credible sets are the most confident ones, whatever the fine-mapping method."""
         confidence = {
             row["studyLocusId"]: row["confidence"]
             for row in self.study_locus.assign_confidence(use_replication=True)
@@ -1469,11 +1468,10 @@ class TestStudyLocusConfidenceWithReplication:
         assert confidence == {
             "1": CredibleSetConfidenceClasses.REPLICATED.value,
             "2": CredibleSetConfidenceClasses.FINEMAPPED_IN_SAMPLE_LD.value,
-            "3": CredibleSetConfidenceClasses.REPLICATED_TOP_HIT.value,
+            "3": CredibleSetConfidenceClasses.REPLICATED.value,
             "4": CredibleSetConfidenceClasses.PICSED_TOP_HIT.value,
             "5": CredibleSetConfidenceClasses.FINEMAPPED_OUT_OF_SAMPLE_LD.value,
             "6": CredibleSetConfidenceClasses.UNKNOWN.value,
-            "7": CredibleSetConfidenceClasses.REPLICATED.value,
         }
 
     def test_replication_is_ignored_by_default(
@@ -1483,10 +1481,7 @@ class TestStudyLocusConfidenceWithReplication:
         assert (
             self.study_locus.assign_confidence()
             .df.filter(
-                f.col("confidence").isin(
-                    CredibleSetConfidenceClasses.REPLICATED.value,
-                    CredibleSetConfidenceClasses.REPLICATED_TOP_HIT.value,
-                )
+                f.col("confidence") == CredibleSetConfidenceClasses.REPLICATED.value
             )
             .count()
             == 0


### PR DESCRIPTION
## Summary

Flags the credible sets whose lead variant is replicated in an independent study. The replication logic is the one behind the `replicated_gwas_cs` / `replicated_molqtl_cs` tables of the manuscript's data preparation notebooks.

- `StudyLocusQualityCheck.REPLICATED`, raised by the new `StudyLocus.qc_replication(study_index)`.
- Wired into `StudyLocusValidationStep`.

The flag is positive: it records that a credible set *is* replicated. Nothing is ever flagged as a failure to replicate, so `REPLICATED` is never a reason to consider a credible set invalid, and its absence carries no claim — a credible set that was never assessed simply does not have it.

## Logic

A GWAS credible set is replicated if its lead variant is associated with the same diseases in at least two independent studies. GWAS studies have to agree on their **full list** of diseases: two studies sharing a single disease out of several describe different phenotypes and are not a replication of one another. Studies agreeing on `cohorts`, `pubmedId` and `ldPopulationStructure` are the same evidence twice over and are collapsed before counting.

A molQTL credible set is replicated if its lead variant is associated with the same gene in at least two studies.

GWAS studies with no disease annotation and molQTL studies with no measured gene have nothing to replicate on, so their credible sets are left unflagged rather than reported as unreplicated.

## Placement in the validation step

`qc_replication` runs at the very end of `StudyLocusValidationStep`, after both valid/invalid splits, on the credible sets that passed every other check and survived the duplicate check. A credible set removed by an earlier flag is not evidence of replication, and two duplicated credible sets of one study must not count as two studies.

## Not in this PR

The confidence part is proposed separately. Replication does not feed `assign_confidence` here, there is no new `CredibleSetConfidenceClasses` member, and the `credibleSetConfidence` L2G feature is untouched.
