### PR TITLE
fix(cluster): force HTTP/1.1 for git, working around a GitHub defect

### DIFF
--- a/utils/install_dependencies_on_cluster.sh
+++ b/utils/install_dependencies_on_cluster.sh
@@ -49,6 +49,14 @@ function main() {
     install_pip
     pip install uv
 
+    # Temporary: a GitHub HTTP/2 defect makes unauthenticated fetches fail on the git
+    # this image ships (2.30.2). The advertisement returns 200, the pack negotiation
+    # returns 401, and git reports it as a missing username. uv shells out to
+    # /usr/bin/git, so this applies to the install below.
+    # https://github.com/orgs/community/discussions/206581
+    # Remove once GitHub resolves it.
+    git config --global http.version HTTP/1.1
+
     echo "Install package..."
     uv pip install --system --upgrade opencv-python pandas numpy pyarrow scipy
     run_with_retry uv pip install --no-break-system-packages --system "gentropy @ git+${REPO_URI}.git@${GENTROPY_REF}"


### PR DESCRIPTION
Since 2 September, unauthenticated `git fetch` over HTTPS fails against GitHub on the git the Dataproc image ships (2.30.2). This init action installs `gentropy` from a git URL, so it fails on every node and the cluster comes up in `ERROR` state.

Found while running the Open Targets unified pipeline: run `do/platform-2609-1` was stopped with 415 tasks `upstream_failed`, `gentropy_biosample.cluster_create_gentropy` among the failures. Tracked in opentargets/issues#4520.

## The failure

```
GET  /info/refs?service=git-upload-pack   ->  200
POST /git-upload-pack                     ->  401
```

git reads the 401 as a credential challenge, finds no credentials, and reports:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
fatal: expected flush after ref listing
```

which reads like a configuration problem but is not one. GitHub has acknowledged it as an HTTP/2 defect — [community/discussions#206581](https://github.com/orgs/community/discussions/206581), reported ~11:00 CET on 2 September, no permanent fix announced.

It is version-dependent: reproduces on git 2.30.2 (Debian bullseye, the Dataproc image) and not on 2.50.1.

## The fix

```bash
git config --global http.version HTTP/1.1
```

`uv` shells out to `/usr/bin/git`, so a global git setting reaches the install below. Verified against the exact fetch `uv` performs:

```
git 2.30.2:
  default (HTTP/2)        fatal: could not read Username / expected flush after ref listing
  http.version=HTTP/1.1   commit fetched OK
```

**Temporary.** It should be removed once GitHub resolves the defect; the comment in the script says so.

## Why not install from PyPI instead

`gentropy` publishes to PyPI, which would avoid git entirely — but only final releases. Both PyPI and TestPyPI stop at `3.3.0`; there is no `3.4.x`. The pipeline currently pins `3.4.0-rc.1`, which exists only as a git ref and a ghcr image, so git is the only source for it today.

Publishing pre-releases would be a sturdier long-term answer, and is worth considering separately from this outage.

## Deployment

This file is deployed by `make sync-cluster-init-script`, which copies it to `gs://genetics_etl_python_playground/initialisation/`. The repo copy currently matches what is deployed, so that sync is all it needs.
