### PR TITLE
fix: use git config --system in the cluster init action

### DIFF
--- a/utils/install_dependencies_on_cluster.sh
+++ b/utils/install_dependencies_on_cluster.sh
@@ -49,13 +49,12 @@ function main() {
     install_pip
     pip install uv
 
-    # Temporary: a GitHub HTTP/2 defect makes unauthenticated fetches fail on the git
-    # this image ships (2.30.2). The advertisement returns 200, the pack negotiation
-    # returns 401, and git reports it as a missing username. uv shells out to
-    # /usr/bin/git, so this applies to the install below.
+    # Temporary: a GitHub HTTP/2 defect makes unauthenticated fetches fail on the
+    # git this image ships (2.30.2) -- the ref advertisement returns 200, the pack
+    # negotiation 401. uv shells out to /usr/bin/git, so this covers the install
+    # below. Remove once GitHub resolves it.
     # https://github.com/orgs/community/discussions/206581
-    # Remove once GitHub resolves it.
-    git config --global http.version HTTP/1.1
+    git config --system http.version HTTP/1.1
 
     echo "Install package..."
     uv pip install --system --upgrade opencv-python pandas numpy pyarrow scipy


### PR DESCRIPTION
Follow-up to the HTTP/1.1 workaround. That change is correct in intent but used the wrong scope, and it took down every Dataproc cluster in `do/platform-2609-1` — the same symptom as the GitHub defect it works around.

## What happened

```
+ pip install uv
Successfully installed uv-0.12.9
+ git config --global http.version HTTP/1.1
fatal: $HOME not set
```

A Dataproc init action runs with no `$HOME`. `git config --global` needs it to locate `~/.gitconfig` and aborts rather than falling back — and under `set -e` that fails the init action, so the cluster never reaches RUNNING. The workaround failed one line *before* the install it was added to protect.

Result: 6 clusters in `ERROR`, 13 failed tasks, 431 `upstream_failed`, run dead 29 minutes in.

## The fix

`--system` writes `/etc/gitconfig`, needs no `$HOME`, and applies to whichever user `uv` shells out to git as.

## Verified

In `debian:bullseye`, git 2.30.2 — the exact version the Dataproc image ships:

```
$ env -u HOME git config --global http.version HTTP/1.1
fatal: $HOME not set                                    -> reproduces the outage

$ env -u HOME git config --system http.version HTTP/1.1
                                                        -> succeeds

$ env -u HOME git config --list --show-origin | grep http.version
file:/etc/gitconfig     http.version=HTTP/1.1           -> visible to later git, HOME still unset
```

Testing the previous fix this way would have caught it before the run. It was reasoned about rather than executed.

Still temporary — remove along with the rest of the workaround once GitHub resolves [community/discussions#206581](https://github.com/orgs/community/discussions/206581).
