### PR TITLE
fix(qc): run the study locus duplicate check after the other flags

### DIFF
--- a/src/gentropy/dataset/study_locus.py
+++ b/src/gentropy/dataset/study_locus.py
@@ -397,6 +397,11 @@ class StudyLocus(Dataset):
         Credible sets of equal size are left to the arbitrary default ordering, since neither is
         better resolved than the other.
 
+        Call this on credible sets that already passed the other quality checks. The ordering only
+        looks at credible set size, so on unfiltered input it can elect a credible set that another
+        flag is about to drop, discarding the surviving copy along with it -- which is what happens
+        to a curated top hit paired with the PICS credible set of the same study and lead variant.
+
         Returns:
             StudyLocus: with flagged duplicated studies.
         """

--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -55,11 +55,6 @@ class StudyLocusValidationStep:
             .qc_explained_by_SuSiE()  # Flagging credible sets in regions explained by SuSiE
             # Annotates credible intervals and filter to only keep 95% credible sets
             .filter_credible_set(credible_interval=CredibleInterval.IS95)
-            # Flagging credible sets with a non-unique identifier. The input is a union of several
-            # independently generated datasets, so uniqueness can only be established here. Runs
-            # after the 95% filter so that the smallest-credible-set rule sees the credible sets
-            # themselves rather than the full set of tagging variants.
-            .validate_unique_study_locus_id()
             # Flagging credible sets with PIP > 1 or PIP < 0.95
             .qc_abnormal_pips(
                 sum_pips_lower_threshold=0.95,
@@ -74,9 +69,23 @@ class StudyLocusValidationStep:
 
         result = study_locus_with_qc.valid_rows(invalid_qc_reasons)
 
+        # `studyLocusId` is a hash of the study and the lead variant, and the input is a union of
+        # several independently generated datasets, so uniqueness can only be established here.
+        # It is checked on the credible sets that survived the other flags, never on the whole
+        # input: a curated top hit collides with the PICS credible set of the same study and lead
+        # variant, and the top hit holds the smaller `locus` of the two, so ordering the whole
+        # input by credible set size elects the top hit -- itself already dropped under
+        # TOP_HIT_AND_SUMMARY_STATS -- and flags the fine-mapped credible set, losing both.
+        deduplicated = (
+            result.valid.validate_unique_study_locus_id().persist()
+        )  # we will need this for 2 types of outputs
+        # None of the other reasons can match here, so this only separates the duplicates, and
+        # only when DUPLICATED_STUDYLOCUS_ID is one of the configured invalid reasons.
+        unique = deduplicated.valid_rows(invalid_qc_reasons)
+
         (
             # Valid study locus partitioned to simplify the finding of overlaps
-            result.valid.df.repartitionByRange(
+            unique.valid.df.repartitionByRange(
                 session.output_partitions,
                 "chromosome",
                 "position",
@@ -86,7 +95,8 @@ class StudyLocusValidationStep:
             .parquet(valid_study_locus_path)
         )
         (
-            result.invalid.df.coalesce(session.output_partitions)
+            result.invalid.df.unionByName(unique.invalid.df)
+            .coalesce(session.output_partitions)
             .write.mode(session.write_mode)
             .parquet(invalid_study_locus_path)
         )

--- a/src/gentropy/study_locus_validation.py
+++ b/src/gentropy/study_locus_validation.py
@@ -100,3 +100,7 @@ class StudyLocusValidationStep:
             .write.mode(session.write_mode)
             .parquet(invalid_study_locus_path)
         )
+
+        # Both caches feed the invalid output, so they can only be released once it is written.
+        deduplicated.df.unpersist()
+        study_locus_with_qc.df.unpersist()


### PR DESCRIPTION
## What is wrong

`validate_unique_study_locus_id` ran over the whole validation input, before `valid_rows`. Its ordering only looks at `size(locus)`, so it could elect a credible set that another flag was already dropping and flag the surviving copy instead — losing both members of the pair.

That is exactly what happens to GWAS Catalog top hits. A curated top hit and the PICS credible set built from the same study's summary statistics share study and lead variant, so they hash to the same `studyLocusId`. The top hit carries the smaller `locus` of the two, so it always won the tie-break — while being invalid itself under `TOP_HIT_AND_SUMMARY_STATS`, which exists precisely to drop the top hit when summary statistics are available.

## Impact measured on the release data

In `do/platform-2609-1` this removed **44,671 GWAS credible sets** that 26.06 published. All of them are PICS, and in every single case the surviving twin is in the excluded output:

| surviving twin's own flags | groups |
|---|---|
| `TOP_HIT_AND_SUMMARY_STATS` + curated top hit | 43,906 |
| curated top hit | 579 |
| the above plus LD / window clumping, subsignificant | ~266 |

Group sizes: 44,607 pairs, 64 groups of 3 or more. The credible sets lost are the better resolved copy of each pair.

This is also why GWAS credible sets did not grow in that run despite 142,407 more input credible sets and 14,695 more valid GWAS studies: the new input added about 44.4k credible sets and this flag removed 44,671, for a net of -300.

## The check was doing no useful work

Both releases publish zero duplicated `studyLocusId` — 3,518,871 rows in 26.06 and 5,872,930 in 2609-1, all distinct. 26.06 did not have the check at all, and was unaffected: the collision is structural, and `qc_redundant_top_hits_from_PICS` / `TOP_HIT_AND_SUMMARY_STATS` already removed exactly one member of every colliding pair.

Of the 452,721 rows the check flagged in 2609-1, 408,050 already carried another invalidating flag and the remaining 44,671 all had a doomed twin. So it removed nothing that was not already being removed, and cost 44,671 credible sets.

## The change

The check now runs on the credible sets that passed the other flags, so a doomed row can no longer be elected as the survivor. It stays as a guard against a genuine collision between two otherwise valid credible sets, and it still honours the configured `invalid_qc_reasons`: the flag is raised either way, and rows are only separated when `DUPLICATED_STUDYLOCUS_ID` is one of the configured reasons.

Rows newly flagged as duplicates are unioned into the invalid output, so nothing is dropped silently.

## Notes

- Regression introduced by #1274, which wired this check into the step for the first time.
- Existing `TestStudyLocusDuplicationFlagging` tests cover the method itself and are unchanged — the method's behaviour is the same, only its position in the step moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
